### PR TITLE
Allow dev-master package of phayes/geophp to be allowed in composer.j…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.0",
         "ext-json": "*",
         "laravel/framework": "^8.0|^9.0",
-        "phayes/geophp": "^1.2"
+        "phayes/geophp": "^1.2|dev-master"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
I've been testing out your Laravel Eloquent Spatial package.  I noticed it had a requirement for geophp 1.2.  We've been using dev-master as it contains a few fixes around centroid and includes invertxy etc..

This pull request allows dev-master to be allowed as well.