### PR TITLE
Excluding WKT option for mariaDB server

### DIFF
--- a/src/GeometryCast.php
+++ b/src/GeometryCast.php
@@ -70,7 +70,10 @@ class GeometryCast implements CastsAttributes
     }
 
     $wkt = $value->toWkt();
-
+    $serverVersion = $model->getQuery()->getConnection()->getPDO()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+    if (preg_match('/mariadb/i', $serverVersion)) {
+      return DB::raw("ST_GeomFromText('{$wkt}', {$value->srid})");
+    }
     return DB::raw("ST_GeomFromText('{$wkt}', {$value->srid}, 'axis-order=long-lat')");
   }
 

--- a/src/SpatialBuilder.php
+++ b/src/SpatialBuilder.php
@@ -264,7 +264,10 @@ class SpatialBuilder extends Builder
   {
     if ($geometryOrColumn instanceof Geometry) {
       $wkt = $geometryOrColumn->toWkt();
-
+      $serverVersion = $this->getQuery()->getConnection()->getPDO()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+      if (preg_match('/mariadb/i', $serverVersion)) {
+        return DB::raw("ST_GeomFromText('{$wkt}', {$value->srid})");
+      }
       return DB::raw("ST_GeomFromText('{$wkt}', {$geometryOrColumn->srid}, 'axis-order=long-lat')");
     }
 


### PR DESCRIPTION
Unlike MySQL, the WKT-input spatial analysis functions in MariaDB (like ST_GeomFromText and ST_DISTANCE) do not take an options parameter