### PR TITLE
Cast geometry from array

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,6 +13,7 @@
 Geometry classes can be also created by these static methods:
 
 * `fromJson(string $geoJson, int $srid = 0)` - Creates a geometry object from a [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) string.
+* `fromArray(array $geometry)` - Creates a geometry object from a array. Reverse to `->toArray()` method.
 * `fromWkt(string $wkt, int $srid = 0)` - Creates a geometry object from a [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry).
 * `fromWkb(string $wkb, int $srid = 0)` - Creates a geometry object from a [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary).
 

--- a/src/GeometryCast.php
+++ b/src/GeometryCast.php
@@ -62,8 +62,8 @@ class GeometryCast implements CastsAttributes
       return null;
     }
 
-    if (is_array($value) && isset($value['type']) && $value['type'] === class_basename($this->className)) {
-        $value = Geometry::fromJson(json_encode($value));
+    if (is_array($value)) {
+        $value = Geometry::fromArray($value);
     }
 
     if (! ($value instanceof $this->className)) {

--- a/src/GeometryCast.php
+++ b/src/GeometryCast.php
@@ -62,6 +62,10 @@ class GeometryCast implements CastsAttributes
       return null;
     }
 
+    if (is_array($value) && isset($value['type']) && $value['type'] === class_basename($this->className)) {
+        $value = Geometry::fromJson(json_encode($value));
+    }
+
     if (! ($value instanceof $this->className)) {
       $geometryType = is_object($value) ? $value::class : gettype($value);
       throw new InvalidArgumentException(

--- a/src/Objects/Geometry.php
+++ b/src/Objects/Geometry.php
@@ -15,6 +15,7 @@ use JsonException;
 use JsonSerializable;
 use MatanYadaev\EloquentSpatial\Factory;
 use MatanYadaev\EloquentSpatial\GeometryCast;
+use OutOfBoundsException;
 use Stringable;
 use WKB as geoPHPWkb;
 
@@ -106,26 +107,41 @@ abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializab
     return $geometry;
   }
 
-  /**
-   * @param  string  $geoJson
-   * @param  int  $srid
-   * @return static
-   *
-   * @throws InvalidArgumentException
-   */
-  public static function fromJson(string $geoJson, int $srid = 0): static
-  {
-    $geometry = Factory::parse($geoJson);
-    $geometry->srid = $srid;
+    /**
+     * @param  string  $geoJson
+     * @param  int  $srid
+     * @return static
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function fromJson(string $geoJson, int $srid = 0): static
+    {
+        $geometry = Factory::parse($geoJson);
+        $geometry->srid = $srid;
 
-    if (! ($geometry instanceof static)) {
-      throw new InvalidArgumentException(
-        sprintf('Expected %s, %s given.', static::class, $geometry::class)
-      );
+        if (! ($geometry instanceof static)) {
+            throw new InvalidArgumentException(
+                sprintf('Expected %s, %s given.', static::class, $geometry::class)
+            );
+        }
+
+        return $geometry;
     }
 
-    return $geometry;
-  }
+    /**
+     * @param  array  $geometry
+     * @return static
+     *
+     * @throws OutOfBoundsException
+     */
+    public static function fromArray(array $geometry): static
+    {
+        if (! isset($geometry['type'])) {
+            throw new OutOfBoundsException('Your geometry doesn\'t contain "type"');
+        }
+
+        return static::fromJson(json_encode($geometry));
+    }
 
   /**
    * @return array<mixed>

--- a/src/Objects/Geometry.php
+++ b/src/Objects/Geometry.php
@@ -15,7 +15,6 @@ use JsonException;
 use JsonSerializable;
 use MatanYadaev\EloquentSpatial\Factory;
 use MatanYadaev\EloquentSpatial\GeometryCast;
-use OutOfBoundsException;
 use Stringable;
 use WKB as geoPHPWkb;
 
@@ -116,31 +115,25 @@ abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializab
      */
     public static function fromJson(string $geoJson, int $srid = 0): static
     {
-        $geometry = Factory::parse($geoJson);
-        $geometry->srid = $srid;
+      $geometry = Factory::parse($geoJson);
+      $geometry->srid = $srid;
 
-        if (! ($geometry instanceof static)) {
-            throw new InvalidArgumentException(
-                sprintf('Expected %s, %s given.', static::class, $geometry::class)
-            );
-        }
+      if (! ($geometry instanceof static)) {
+        throw new InvalidArgumentException(
+          sprintf('Expected %s, %s given.', static::class, $geometry::class)
+        );
+      }
 
-        return $geometry;
+      return $geometry;
     }
 
     /**
-     * @param  array  $geometry
+     * @param  array<mixed> $geometry
      * @return static
-     *
-     * @throws OutOfBoundsException
      */
     public static function fromArray(array $geometry): static
     {
-        if (! isset($geometry['type'])) {
-            throw new OutOfBoundsException('Your geometry doesn\'t contain "type"');
-        }
-
-        return static::fromJson(json_encode($geometry));
+      return static::fromJson(json_encode($geometry));
     }
 
   /**

--- a/tests/Objects/GeometryCollectionTest.php
+++ b/tests/Objects/GeometryCollectionTest.php
@@ -70,25 +70,6 @@ it('creates geometry collection from JSON', function (): void {
     expect($geometryCollectionFromJson)->toEqual($geometryCollection);
 });
 
-it('creates geometry collection from array (serialized model)', function (): void {
-    $geometryCollection = new GeometryCollection([
-      new Polygon([
-        new LineString([
-          new Point(0, 180),
-          new Point(1, 179),
-          new Point(2, 178),
-          new Point(3, 177),
-          new Point(0, 180),
-        ]),
-      ]),
-      new Point(0, 180),
-    ]);
-
-    $geometryCollectionFromArray = GeometryCollection::fromArray($geometryCollection->toArray());
-
-    expect($geometryCollectionFromArray)->toEqual($geometryCollection);
-});
-
 it('creates geometry collection with SRID from JSON', function (): void {
   $geometryCollection = new GeometryCollection([
     new Polygon([

--- a/tests/Objects/GeometryCollectionTest.php
+++ b/tests/Objects/GeometryCollectionTest.php
@@ -52,22 +52,41 @@ it('creates a model record with geometry collection with SRID', function (): voi
 });
 
 it('creates geometry collection from JSON', function (): void {
-  $geometryCollection = new GeometryCollection([
-    new Polygon([
-      new LineString([
-        new Point(0, 180),
-        new Point(1, 179),
-        new Point(2, 178),
-        new Point(3, 177),
-        new Point(0, 180),
+    $geometryCollection = new GeometryCollection([
+      new Polygon([
+        new LineString([
+          new Point(0, 180),
+          new Point(1, 179),
+          new Point(2, 178),
+          new Point(3, 177),
+          new Point(0, 180),
+        ]),
       ]),
-    ]),
-    new Point(0, 180),
-  ]);
+      new Point(0, 180),
+    ]);
 
-  $geometryCollectionFromJson = GeometryCollection::fromJson('{"type":"GeometryCollection","geometries":[{"type":"Polygon","coordinates":[[[180,0],[179,1],[178,2],[177,3],[180,0]]]},{"type":"Point","coordinates":[180,0]}]}');
+    $geometryCollectionFromJson = GeometryCollection::fromJson('{"type":"GeometryCollection","geometries":[{"type":"Polygon","coordinates":[[[180,0],[179,1],[178,2],[177,3],[180,0]]]},{"type":"Point","coordinates":[180,0]}]}');
 
-  expect($geometryCollectionFromJson)->toEqual($geometryCollection);
+    expect($geometryCollectionFromJson)->toEqual($geometryCollection);
+});
+
+it('creates geometry collection from array (serialized model)', function (): void {
+    $geometryCollection = new GeometryCollection([
+      new Polygon([
+        new LineString([
+          new Point(0, 180),
+          new Point(1, 179),
+          new Point(2, 178),
+          new Point(3, 177),
+          new Point(0, 180),
+        ]),
+      ]),
+      new Point(0, 180),
+    ]);
+
+    $geometryCollectionFromArray = GeometryCollection::fromArray($geometryCollection->toArray());
+
+    expect($geometryCollectionFromArray)->toEqual($geometryCollection);
 });
 
 it('creates geometry collection with SRID from JSON', function (): void {

--- a/tests/Objects/GeometryTest.php
+++ b/tests/Objects/GeometryTest.php
@@ -3,8 +3,11 @@
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use MatanYadaev\EloquentSpatial\AxisOrder;
+use MatanYadaev\EloquentSpatial\Objects\Geometry;
+use MatanYadaev\EloquentSpatial\Objects\GeometryCollection;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Objects\Polygon;
 use MatanYadaev\EloquentSpatial\Tests\TestModels\TestPlace;
 
 it('throws exception when generating geometry from other geometry WKB', function (): void {
@@ -76,5 +79,47 @@ it('throws exception when generating geometry from other geometry JSON', functio
     $pointJson = '{"type":"Point","coordinates":[0,180]}';
 
     LineString::fromJson($pointJson);
+  })->toThrow(InvalidArgumentException::class);
+});
+
+it('creates geometry collection from array (serialized model)', function (): void {
+  $geometryCollection = new GeometryCollection([
+    new Polygon([
+      new LineString([
+        new Point(0, 180),
+        new Point(1, 179),
+        new Point(2, 178),
+        new Point(3, 177),
+        new Point(0, 180),
+      ]),
+    ]),
+    new Point(0, 180),
+  ]);
+  $geometryCollectionArray = $geometryCollection->toArray();
+
+  $geometryCollectionFromArray = GeometryCollection::fromArray($geometryCollectionArray);
+
+  expect($geometryCollectionFromArray)->toEqual($geometryCollection);
+});
+
+it('throws exception when generating geometry from wrong array', function (): void {
+  expect(function (): void {
+    $geometryCollectionArray = [
+      'type' => 'Point2',
+      'coordinates' => [0, 180],
+    ];
+
+    Geometry::fromArray($geometryCollectionArray);
+  })->toThrow(InvalidArgumentException::class);
+});
+
+it('throws exception when generating geometry from other geometry array', function (): void {
+  expect(function (): void {
+    $geometryCollectionArray = [
+      'type' => 'Point',
+      'coordinates' => [0, 180],
+    ];
+
+    LineString::fromArray($geometryCollectionArray);
   })->toThrow(InvalidArgumentException::class);
 });


### PR DESCRIPTION
At now we can do `$serialize = Model::find(35)->toArray();` but cant use `$model = new Model($serialize)`. This PR look to values and try to use `Geometry::fromJson()` to serialized array.