### PR TITLE
Support receiving `Expression` as a parameter in `SpatialBuilder` methods

### DIFF
--- a/API.md
+++ b/API.md
@@ -75,7 +75,7 @@ Retrieves the distance between 2 geometry objects. Uses [ST_Distance](https://de
 
 | parameter name      | type                | default      |
 |---------------------|---------------------|--------------|
-| `$column`           | `string`            |              |
+| `$column`           | `Geometry \ string` |              |
 | `$geometryOrColumn` | `Geometry \ string` |              |
 | `$alias`            | `string`            | `'distance'` |
 
@@ -105,7 +105,7 @@ Filters records by distance. Uses [ST_Distance](https://dev.mysql.com/doc/refman
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 | `$operator`         | `string`            |
 | `$value`            | `int \ float`       |
@@ -130,7 +130,7 @@ Orders records by distance. Uses [ST_Distance](https://dev.mysql.com/doc/refman/
 
 | parameter name      | type                | default |
 |---------------------|---------------------|---------|
-| `$column`           | `string`            |         |
+| `$column`           | `Geometry \ string` |         |
 | `$geometryOrColumn` | `Geometry \ string` |         |
 | `$direction`        | `string`            | `'asc'` |
 
@@ -161,7 +161,7 @@ Retrieves the spherical distance between 2 geometry objects. Uses [ST_Distance_S
 
 | parameter name      | type                | default      |
 |---------------------|---------------------|--------------|
-| `$column`           | `string`            |              |
+| `$column`           | `Geometry \ string` |              |
 | `$geometryOrColumn` | `Geometry \ string` |              |
 | `$alias`            | `string`            | `'distance'` |
 
@@ -191,7 +191,7 @@ Filters records by spherical distance. Uses [ST_Distance_Sphere](https://dev.mys
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 | `$operator`         | `string`            |
 | `$value`            | `int \ float`       |
@@ -216,7 +216,7 @@ Orders records by spherical distance. Uses [ST_Distance_Sphere](https://dev.mysq
 
 | parameter name      | type                | default |
 |---------------------|---------------------|---------|
-| `$column`           | `string`            |         |
+| `$column`           | `Geometry \ string` |         |
 | `$geometryOrColumn` | `Geometry \ string` |         |
 | `$direction`        | `string`            | `'asc'` |
 
@@ -247,7 +247,7 @@ Filters records by the [ST_Within](https://dev.mysql.com/doc/refman/8.0/en/spati
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -267,7 +267,7 @@ Filters records by the [ST_Within](https://dev.mysql.com/doc/refman/8.0/en/spati
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -287,7 +287,7 @@ Filters records by the [ST_Contains](https://dev.mysql.com/doc/refman/8.0/en/spa
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -307,7 +307,7 @@ Filters records by the [ST_Contains](https://dev.mysql.com/doc/refman/8.0/en/spa
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -327,7 +327,7 @@ Filters records by the [ST_Touches](https://dev.mysql.com/doc/refman/8.0/en/spat
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -347,7 +347,7 @@ Filters records by the [ST_Intersects](https://dev.mysql.com/doc/refman/8.0/en/s
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -367,7 +367,7 @@ Filters records by the [ST_Crosses](https://dev.mysql.com/doc/refman/8.0/en/spat
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -387,7 +387,7 @@ Filters records by the [ST_Disjoint](https://dev.mysql.com/doc/refman/8.0/en/spa
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -407,7 +407,7 @@ Filters records by the [ST_Equal](https://dev.mysql.com/doc/refman/8.0/en/spatia
 
 | parameter name      | type                |
 |---------------------|---------------------|
-| `$column`           | `string`            |
+| `$column`           | `Geometry \ string` |
 | `$geometryOrColumn` | `Geometry \ string` |
 
 <details><summary>Example</summary>
@@ -425,11 +425,11 @@ Place::query()
 
 Filters records by the [ST_Srid](https://dev.mysql.com/doc/refman/8.0/en/gis-general-property-functions.html#function_st-srid) function.
 
-| parameter name | type     |
-|----------------|----------|
-| `$column`      | `string` |
-| `$operator`    | `string` |
-| `$value`       | `int`    |
+| parameter name | type                |
+|----------------|---------------------|
+| `$column`      | `Geometry \ string` |
+| `$operator`    | `string`            |
+| `$value`       | `int`               |
 
 <details><summary>Example</summary>
 
@@ -441,4 +441,3 @@ Place::query()
     ->exists(); // true
 ```
 </details>
-

--- a/src/SpatialBuilder.php
+++ b/src/SpatialBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MatanYadaev\EloquentSpatial;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use Illuminate\Support\Facades\DB;
 use MatanYadaev\EloquentSpatial\Objects\Geometry;
 
@@ -19,8 +19,8 @@ use MatanYadaev\EloquentSpatial\Objects\Geometry;
 class SpatialBuilder extends Builder
 {
   public function withDistance(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
     string $alias = 'distance'
   ): self
   {
@@ -41,8 +41,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereDistance(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
     string $operator,
     int|float $value
   ): self
@@ -61,8 +61,8 @@ class SpatialBuilder extends Builder
   }
 
   public function orderByDistance(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
     string $direction = 'asc'
   ): self
   {
@@ -79,8 +79,8 @@ class SpatialBuilder extends Builder
   }
 
   public function withDistanceSphere(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
     string $alias = 'distance'
   ): self
   {
@@ -101,8 +101,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereDistanceSphere(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
     string $operator,
     int|float $value
   ): self
@@ -121,8 +121,8 @@ class SpatialBuilder extends Builder
   }
 
   public function orderByDistanceSphere(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
     string $direction = 'asc'
   ): self
   {
@@ -139,8 +139,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereWithin(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -155,8 +155,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereNotWithin(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -171,8 +171,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereContains(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -187,8 +187,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereNotContains(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -203,8 +203,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereTouches(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -219,8 +219,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereIntersects(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -235,8 +235,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereCrosses(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -251,8 +251,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereDisjoint(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -267,8 +267,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereOverlaps(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -283,8 +283,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereEquals(
-    Expression|Geometry|string $column,
-    Expression|Geometry|string $geometryOrColumn,
+    ExpressionContract|Geometry|string $column,
+    ExpressionContract|Geometry|string $geometryOrColumn,
   ): self
   {
     $this->whereRaw(
@@ -299,7 +299,7 @@ class SpatialBuilder extends Builder
   }
 
   public function whereSrid(
-    Expression|Geometry|string $column,
+    ExpressionContract|Geometry|string $column,
     string $operator,
     int|float $value
   ): self
@@ -316,11 +316,11 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  protected function toExpressionString(Expression|Geometry|string $geometryOrColumnOrExpression): string
+  protected function toExpressionString(ExpressionContract|Geometry|string $geometryOrColumnOrExpression): string
   {
     $grammar = $this->getQuery()->getGrammar();
 
-    if ($geometryOrColumnOrExpression instanceof Expression) {
+    if ($geometryOrColumnOrExpression instanceof ExpressionContract) {
       $expression = $geometryOrColumnOrExpression;
     } else if ($geometryOrColumnOrExpression instanceof Geometry) {
       $expression = $geometryOrColumnOrExpression->toSqlExpression($this->getConnection());

--- a/src/SpatialBuilder.php
+++ b/src/SpatialBuilder.php
@@ -19,8 +19,8 @@ use MatanYadaev\EloquentSpatial\Objects\Geometry;
 class SpatialBuilder extends Builder
 {
   public function withDistance(
-    Expression|string $column,
-    Geometry|string $geometryOrColumn,
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
     string $alias = 'distance'
   ): self
   {
@@ -31,7 +31,7 @@ class SpatialBuilder extends Builder
     $this->selectRaw(
       sprintf(
         'ST_DISTANCE(%s, %s) AS %s',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
         $alias,
       )
@@ -41,8 +41,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereDistance(
-    Expression|string $column,
-    Geometry|string $geometryOrColumn,
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
     string $operator,
     int|float $value
   ): self
@@ -50,7 +50,7 @@ class SpatialBuilder extends Builder
     $this->whereRaw(
       sprintf(
         'ST_DISTANCE(%s, %s) %s ?',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
         $operator,
       ),
@@ -61,15 +61,15 @@ class SpatialBuilder extends Builder
   }
 
   public function orderByDistance(
-    Expression|string $column,
-    Geometry|string $geometryOrColumn,
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
     string $direction = 'asc'
   ): self
   {
     $this->orderByRaw(
       sprintf(
         'ST_DISTANCE(%s, %s) %s',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
         $direction,
       )
@@ -79,8 +79,8 @@ class SpatialBuilder extends Builder
   }
 
   public function withDistanceSphere(
-    Expression|string $column,
-    Geometry|string $geometryOrColumn,
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
     string $alias = 'distance'
   ): self
   {
@@ -91,7 +91,7 @@ class SpatialBuilder extends Builder
     $this->selectRaw(
       sprintf(
         'ST_DISTANCE_SPHERE(%s, %s) AS %s',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
         $alias,
       )
@@ -101,8 +101,8 @@ class SpatialBuilder extends Builder
   }
 
   public function whereDistanceSphere(
-    Expression|string $column,
-    Geometry|string $geometryOrColumn,
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
     string $operator,
     int|float $value
   ): self
@@ -110,7 +110,7 @@ class SpatialBuilder extends Builder
     $this->whereRaw(
       sprintf(
         'ST_DISTANCE_SPHERE(%s, %s) %s ?',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
         $operator,
       ),
@@ -121,15 +121,15 @@ class SpatialBuilder extends Builder
   }
 
   public function orderByDistanceSphere(
-    Expression|string $column,
-    Geometry|string $geometryOrColumn,
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
     string $direction = 'asc'
   ): self
   {
     $this->orderByRaw(
       sprintf(
         'ST_DISTANCE_SPHERE(%s, %s) %s',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
         $direction
       )
@@ -138,12 +138,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereWithin(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereWithin(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_WITHIN(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -151,12 +154,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereNotWithin(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereNotWithin(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_WITHIN(%s, %s) = 0',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -164,12 +170,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereContains(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereContains(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_CONTAINS(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -177,12 +186,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereNotContains(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereNotContains(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_CONTAINS(%s, %s) = 0',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -190,12 +202,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereTouches(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereTouches(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_TOUCHES(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -203,12 +218,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereIntersects(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereIntersects(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_INTERSECTS(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -216,12 +234,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereCrosses(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereCrosses(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_CROSSES(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -229,12 +250,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereDisjoint(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereDisjoint(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_DISJOINT(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -242,12 +266,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereOverlaps(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereOverlaps(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_OVERLAPS(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -255,12 +282,15 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereEquals(Expression|string $column, Geometry|string $geometryOrColumn): self
+  public function whereEquals(
+    Expression|Geometry|string $column,
+    Expression|Geometry|string $geometryOrColumn,
+  ): self
   {
     $this->whereRaw(
       sprintf(
         'ST_EQUALS(%s, %s)',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $this->toExpression($geometryOrColumn),
       )
     );
@@ -269,7 +299,7 @@ class SpatialBuilder extends Builder
   }
 
   public function whereSrid(
-    string $column,
+    Expression|Geometry|string $column,
     string $operator,
     int|float $value
   ): self
@@ -277,7 +307,7 @@ class SpatialBuilder extends Builder
     $this->whereRaw(
       sprintf(
         'ST_SRID(%s) %s ?',
-        $this->getQuery()->getGrammar()->wrap($column),
+        $this->toExpression($column),
         $operator,
       ),
       [$value],
@@ -286,12 +316,16 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  protected function toExpression(Geometry|string $geometryOrColumn): Expression
+  protected function toExpression(Expression|Geometry|string $geometryOrColumnOrExpression): Expression
   {
-    if ($geometryOrColumn instanceof Geometry) {
-      return $geometryOrColumn->toSqlExpression($this->getConnection());
+    if($geometryOrColumnOrExpression instanceof Expression) {
+      return $geometryOrColumnOrExpression;
     }
 
-    return DB::raw($this->getQuery()->getGrammar()->wrap($geometryOrColumn));
+    if ($geometryOrColumnOrExpression instanceof Geometry) {
+      return $geometryOrColumnOrExpression->toSqlExpression($this->getConnection());
+    }
+
+    return DB::raw($this->getQuery()->getGrammar()->wrap($geometryOrColumnOrExpression));
   }
 }

--- a/src/SpatialBuilder.php
+++ b/src/SpatialBuilder.php
@@ -19,7 +19,7 @@ use MatanYadaev\EloquentSpatial\Objects\Geometry;
 class SpatialBuilder extends Builder
 {
   public function withDistance(
-    string $column,
+    Expression|string $column,
     Geometry|string $geometryOrColumn,
     string $alias = 'distance'
   ): self
@@ -41,7 +41,7 @@ class SpatialBuilder extends Builder
   }
 
   public function whereDistance(
-    string $column,
+    Expression|string $column,
     Geometry|string $geometryOrColumn,
     string $operator,
     int|float $value
@@ -61,7 +61,7 @@ class SpatialBuilder extends Builder
   }
 
   public function orderByDistance(
-    string $column,
+    Expression|string $column,
     Geometry|string $geometryOrColumn,
     string $direction = 'asc'
   ): self
@@ -79,7 +79,7 @@ class SpatialBuilder extends Builder
   }
 
   public function withDistanceSphere(
-    string $column,
+    Expression|string $column,
     Geometry|string $geometryOrColumn,
     string $alias = 'distance'
   ): self
@@ -101,7 +101,7 @@ class SpatialBuilder extends Builder
   }
 
   public function whereDistanceSphere(
-    string $column,
+    Expression|string $column,
     Geometry|string $geometryOrColumn,
     string $operator,
     int|float $value
@@ -121,7 +121,7 @@ class SpatialBuilder extends Builder
   }
 
   public function orderByDistanceSphere(
-    string $column,
+    Expression|string $column,
     Geometry|string $geometryOrColumn,
     string $direction = 'asc'
   ): self
@@ -138,7 +138,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereWithin(string $column, Geometry|string $geometryOrColumn): self
+  public function whereWithin(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -151,7 +151,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereNotWithin(string $column, Geometry|string $geometryOrColumn): self
+  public function whereNotWithin(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -164,7 +164,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereContains(string $column, Geometry|string $geometryOrColumn): self
+  public function whereContains(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -177,7 +177,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereNotContains(string $column, Geometry|string $geometryOrColumn): self
+  public function whereNotContains(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -190,7 +190,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereTouches(string $column, Geometry|string $geometryOrColumn): self
+  public function whereTouches(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -203,7 +203,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereIntersects(string $column, Geometry|string $geometryOrColumn): self
+  public function whereIntersects(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -216,7 +216,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereCrosses(string $column, Geometry|string $geometryOrColumn): self
+  public function whereCrosses(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -229,7 +229,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereDisjoint(string $column, Geometry|string $geometryOrColumn): self
+  public function whereDisjoint(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -242,7 +242,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereOverlaps(string $column, Geometry|string $geometryOrColumn): self
+  public function whereOverlaps(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(
@@ -255,7 +255,7 @@ class SpatialBuilder extends Builder
     return $this;
   }
 
-  public function whereEquals(string $column, Geometry|string $geometryOrColumn): self
+  public function whereEquals(Expression|string $column, Geometry|string $geometryOrColumn): self
   {
     $this->whereRaw(
       sprintf(

--- a/src/SpatialBuilder.php
+++ b/src/SpatialBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MatanYadaev\EloquentSpatial;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use MatanYadaev\EloquentSpatial\Objects\Geometry;
 
@@ -322,7 +322,7 @@ class SpatialBuilder extends Builder
 
     if ($geometryOrColumnOrExpression instanceof ExpressionContract) {
       $expression = $geometryOrColumnOrExpression;
-    } else if ($geometryOrColumnOrExpression instanceof Geometry) {
+    } elseif ($geometryOrColumnOrExpression instanceof Geometry) {
       $expression = $geometryOrColumnOrExpression->toSqlExpression($this->getConnection());
     } else {
       $expression = DB::raw($grammar->wrap($geometryOrColumnOrExpression));

--- a/tests/SpatialBuilderTest.php
+++ b/tests/SpatialBuilderTest.php
@@ -420,35 +420,36 @@ it('uses spatial function on raw expression', function(): void {
   expect($testPlaceWithDistance)->not()->toBeNull();
 });
 
-it('toExpression can handle Expression', function(): void {
+it('toExpressionString can handle Expression', function(): void {
   $spatialBuilder = TestPlace::query();
-  $toExpressionMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpression');
+  $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
-  $result = $toExpressionMethod->invoke($spatialBuilder, DB::raw('POINT(longitude, latitude)'));
+  $result = $toExpressionStringMethod->invoke($spatialBuilder, DB::raw('POINT(longitude, latitude)'));
 
-  expect($result->getValue())->toBe('POINT(longitude, latitude)');
+  expect($result)->toBe('POINT(longitude, latitude)');
 });
 
 
-it('toExpression can handle Geometry', function(): void {
+it('toExpressionString can handle Geometry', function(): void {
   $polygon = Polygon::fromJson('{"type":"Polygon","coordinates":[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]}');
 
   $spatialBuilder = TestPlace::query();
-  $toExpressionMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpression');
+  $grammar = $spatialBuilder->getQuery()->getGrammar();
+  $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
-  $result = $toExpressionMethod->invoke($spatialBuilder, $polygon);
+  $result = $toExpressionStringMethod->invoke($spatialBuilder, $polygon);
 
-  $sqlSerializedPolygon = $polygon->toSqlExpression($spatialBuilder->getConnection())->getValue();
+  $sqlSerializedPolygon = $polygon->toSqlExpression($spatialBuilder->getConnection())->getValue($grammar);
 
-  expect($result->getValue())->toBe($sqlSerializedPolygon);
+  expect($result)->toBe($sqlSerializedPolygon);
 });
 
 
-it('toExpression can handle string', function(): void {
+it('toExpressionString can handle string', function(): void {
   $spatialBuilder = TestPlace::query();
-  $toExpressionMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpression');
+  $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
-  $result = $toExpressionMethod->invoke($spatialBuilder, 'test_places.point');
+  $result = $toExpressionStringMethod->invoke($spatialBuilder, 'test_places.point');
 
-  expect($result->getValue())->toBe('`test_places`.`point`');
+  expect($result)->toBe('`test_places`.`point`');
 });

--- a/tests/SpatialBuilderTest.php
+++ b/tests/SpatialBuilderTest.php
@@ -404,7 +404,7 @@ it('uses spatial function on column that contains its table name', function (): 
   expect($testPlaceWithDistance->distance)->toBe(0.0);
 });
 
-it('uses spatial function on raw expression', function(): void {
+it('uses spatial function on raw expression', function (): void {
   $polygon = Polygon::fromJson('{"type":"Polygon","coordinates":[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]}');
   TestPlace::factory()->create([
     'longitude' => 0,
@@ -420,7 +420,7 @@ it('uses spatial function on raw expression', function(): void {
   expect($testPlaceWithDistance)->not()->toBeNull();
 });
 
-it('toExpressionString can handle Expression', function(): void {
+it('toExpressionString can handle Expression', function (): void {
   $spatialBuilder = TestPlace::query();
   $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
@@ -430,7 +430,7 @@ it('toExpressionString can handle Expression', function(): void {
 });
 
 
-it('toExpressionString can handle Geometry', function(): void {
+it('toExpressionString can handle Geometry', function (): void {
   $polygon = Polygon::fromJson('{"type":"Polygon","coordinates":[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]}');
 
   $spatialBuilder = TestPlace::query();
@@ -445,7 +445,7 @@ it('toExpressionString can handle Geometry', function(): void {
 });
 
 
-it('toExpressionString can handle string', function(): void {
+it('toExpressionString can handle string', function (): void {
   $spatialBuilder = TestPlace::query();
   $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 

--- a/tests/database/migrations/0000_00_00_000000_create_test_places_table.php
+++ b/tests/database/migrations/0000_00_00_000000_create_test_places_table.php
@@ -21,6 +21,8 @@ class CreateTestPlacesTable extends Migration
       $table->multiPolygon('multi_polygon')->nullable();
       $table->geometryCollection('geometry_collection')->nullable();
       $table->point('point_with_line_string_cast')->nullable();
+      $table->decimal('longitude')->nullable();
+      $table->decimal('latitude')->nullable();
     });
   }
 


### PR DESCRIPTION
Currently, the column parameters on the SpatialBuilder class are typehinted as string, so when passing a `DB::raw(...)` expression into the builder, it gets casted to a string first, then re-wrapped as a column value. This causes issues when attempting a query like
 `->whereWithin(DB::raw('point(longitude, latitude)'), MultiPolygon::fromWkt(...))`, 
resulting in `point(longitude, latitude)` being treated as a column name in sql. By avoiding the string cast, the actual raw value passed is used. 

The fix for this was to add the `Expression` typehint (what `DB::raw` returns) so that the implicit string cast does not happen. This is then picked up by the `$this->getQuery()->getGrammar()->wrap` calls (see [here](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Grammar.php#L55-L57), and then [here](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Grammar.php#L216-L219)) resulting in a correct raw value in the sql.
