### PR TITLE
Allow srid enum as srid property aside from integer

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,20 +2,20 @@
 
 ## Available geometry classes
 
-* `Point(float $latitude, float $longitude, int $srid = 0)` - [MySQL Point](https://dev.mysql.com/doc/refman/8.0/en/gis-class-point.html)
-* `MultiPoint(Point[] | Collection<Point> $geometries, int $srid = 0)` - [MySQL MultiPoint](https://dev.mysql.com/doc/refman/8.0/en/gis-class-multipoint.html)
-* `LineString(Point[] | Collection<Point> $geometries, int $srid = 0)` - [MySQL LineString](https://dev.mysql.com/doc/refman/8.0/en/gis-class-linestring.html)
-* `MultiLineString(LineString[] | Collection<LineString> $geometries, int $srid = 0)` - [MySQL MultiLineString](https://dev.mysql.com/doc/refman/8.0/en/gis-class-multilinestring.html)
-* `Polygon(LineString[] | Collection<LineString> $geometries, int $srid = 0)` - [MySQL Polygon](https://dev.mysql.com/doc/refman/8.0/en/gis-class-polygon.html)
-* `MultiPolygon(Polygon[] | Collection<Polygon> $geometries, int $srid = 0)` - [MySQL MultiPolygon](https://dev.mysql.com/doc/refman/8.0/en/gis-class-multipolygon.html)
-* `GeometryCollection(Geometry[] | Collection<Geometry> $geometries, int $srid = 0)` - [MySQL GeometryCollection](https://dev.mysql.com/doc/refman/8.0/en/gis-class-geometrycollection.html)
+* `Point(float $latitude, float $longitude, int|Srid $srid = 0)` - [MySQL Point](https://dev.mysql.com/doc/refman/8.0/en/gis-class-point.html)
+* `MultiPoint(Point[] | Collection<Point> $geometries, int|Srid $srid = 0)` - [MySQL MultiPoint](https://dev.mysql.com/doc/refman/8.0/en/gis-class-multipoint.html)
+* `LineString(Point[] | Collection<Point> $geometries, int|Srid $srid = 0)` - [MySQL LineString](https://dev.mysql.com/doc/refman/8.0/en/gis-class-linestring.html)
+* `MultiLineString(LineString[] | Collection<LineString> $geometries, int|Srid $srid = 0)` - [MySQL MultiLineString](https://dev.mysql.com/doc/refman/8.0/en/gis-class-multilinestring.html)
+* `Polygon(LineString[] | Collection<LineString> $geometries, int|Srid $srid = 0)` - [MySQL Polygon](https://dev.mysql.com/doc/refman/8.0/en/gis-class-polygon.html)
+* `MultiPolygon(Polygon[] | Collection<Polygon> $geometries, int|Srid $srid = 0)` - [MySQL MultiPolygon](https://dev.mysql.com/doc/refman/8.0/en/gis-class-multipolygon.html)
+* `GeometryCollection(Geometry[] | Collection<Geometry> $geometries, int|Srid $srid = 0)` - [MySQL GeometryCollection](https://dev.mysql.com/doc/refman/8.0/en/gis-class-geometrycollection.html)
 
 Geometry classes can be also created by these static methods:
 
 * `fromArray(array $geometry)` - Creates a geometry object from a [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) array.
-* `fromJson(string $geoJson, int $srid = 0)` - Creates a geometry object from a [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) string.
-* `fromWkt(string $wkt, int $srid = 0)` - Creates a geometry object from a [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry).
-* `fromWkb(string $wkb, int $srid = 0)` - Creates a geometry object from a [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary).
+* `fromJson(string $geoJson, int|Srid $srid = 0)` - Creates a geometry object from a [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) string.
+* `fromWkt(string $wkt, int|Srid $srid = 0)` - Creates a geometry object from a [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry).
+* `fromWkb(string $wkb, int|Srid $srid = 0)` - Creates a geometry object from a [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary).
 
 ## Available geometry class methods
 
@@ -58,8 +58,8 @@ An enum is provided with the following values:
 
 | Identifier           | Value  | Description                                                                         |
 |----------------------|--------|-------------------------------------------------------------------------------------|
-| `Srid::WGS84`        | `4326` | [Geographic coordinate system](https://epsg.org/crs_4326/WGS-84.html)               |                                 
-| `Srid::WEB_MERCATOR` | `3857` | [Mercator coordinate system](https://epsg.org/crs_3857/WGS-84-Pseudo-Mercator.html) | 
+| `Srid::WGS84`        | `4326` | [Geographic coordinate system](https://epsg.org/crs_4326/WGS-84.html)               |
+| `Srid::WEB_MERCATOR` | `3857` | [Mercator coordinate system](https://epsg.org/crs_3857/WGS-84-Pseudo-Mercator.html) |
 
 ## Available spatial scopes
 

--- a/API.md
+++ b/API.md
@@ -15,7 +15,7 @@ Geometry classes can be also created by these static methods:
 * `fromArray(array $geometry)` - Creates a geometry object from a [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) array.
 * `fromJson(string $geoJson, int|Srid $srid = 0)` - Creates a geometry object from a [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) string.
 * `fromWkt(string $wkt, int|Srid $srid = 0)` - Creates a geometry object from a [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry).
-* `fromWkb(string $wkb, int|Srid $srid = 0)` - Creates a geometry object from a [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary).
+* `fromWkb(string $wkb)` - Creates a geometry object from a [WKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary).
 
 ## Available geometry class methods
 

--- a/src/Objects/Geometry.php
+++ b/src/Objects/Geometry.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace MatanYadaev\EloquentSpatial\Objects;
 
 use geoPHP;
+use Stringable;
+use JsonException;
+use JsonSerializable;
+use WKB as geoPHPWkb;
+use InvalidArgumentException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Traits\Macroable;
+use MatanYadaev\EloquentSpatial\Factory;
+use Illuminate\Contracts\Support\Jsonable;
+use MatanYadaev\EloquentSpatial\AxisOrder;
+use Illuminate\Contracts\Support\Arrayable;
+use MatanYadaev\EloquentSpatial\Enums\Srid;
+use Illuminate\Database\ConnectionInterface;
+use MatanYadaev\EloquentSpatial\GeometryCast;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Database\ConnectionInterface;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Traits\Macroable;
-use InvalidArgumentException;
-use JsonException;
-use JsonSerializable;
-use MatanYadaev\EloquentSpatial\AxisOrder;
-use MatanYadaev\EloquentSpatial\Factory;
-use MatanYadaev\EloquentSpatial\GeometryCast;
-use Stringable;
-use WKB as geoPHPWkb;
 
 abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializable, Stringable
 {
@@ -96,10 +97,10 @@ abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializab
    *
    * @throws InvalidArgumentException
    */
-  public static function fromWkt(string $wkt, int $srid = 0): static
+  public static function fromWkt(string $wkt, int|Srid $srid = 0): static
   {
     $geometry = Factory::parse($wkt);
-    $geometry->srid = $srid;
+    $geometry->srid = $srid instanceof Srid ? $srid->getValue() : $srid;
 
     if (! ($geometry instanceof static)) {
       throw new InvalidArgumentException(
@@ -117,10 +118,10 @@ abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializab
    *
    * @throws InvalidArgumentException
    */
-  public static function fromJson(string $geoJson, int $srid = 0): static
+  public static function fromJson(string $geoJson, int|Srid $srid = 0): static
   {
     $geometry = Factory::parse($geoJson);
-    $geometry->srid = $srid;
+    $geometry->srid = $srid instanceof Srid ? $srid->getValue() : $srid;
 
     if (! ($geometry instanceof static)) {
       throw new InvalidArgumentException(

--- a/src/Objects/Geometry.php
+++ b/src/Objects/Geometry.php
@@ -5,23 +5,23 @@ declare(strict_types=1);
 namespace MatanYadaev\EloquentSpatial\Objects;
 
 use geoPHP;
-use Stringable;
-use JsonException;
-use JsonSerializable;
-use WKB as geoPHPWkb;
-use InvalidArgumentException;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Traits\Macroable;
-use MatanYadaev\EloquentSpatial\Factory;
-use Illuminate\Contracts\Support\Jsonable;
-use MatanYadaev\EloquentSpatial\AxisOrder;
-use Illuminate\Contracts\Support\Arrayable;
-use MatanYadaev\EloquentSpatial\Enums\Srid;
-use Illuminate\Database\ConnectionInterface;
-use MatanYadaev\EloquentSpatial\GeometryCast;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+use JsonException;
+use JsonSerializable;
+use MatanYadaev\EloquentSpatial\AxisOrder;
+use MatanYadaev\EloquentSpatial\Enums\Srid;
+use MatanYadaev\EloquentSpatial\Factory;
+use MatanYadaev\EloquentSpatial\GeometryCast;
+use Stringable;
+use WKB as geoPHPWkb;
 
 abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializable, Stringable
 {
@@ -100,7 +100,7 @@ abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializab
   public static function fromWkt(string $wkt, int|Srid $srid = 0): static
   {
     $geometry = Factory::parse($wkt);
-    $geometry->srid = $srid instanceof Srid ? $srid->getValue() : $srid;
+    $geometry->srid = $srid instanceof Srid ? $srid->value : $srid;
 
     if (! ($geometry instanceof static)) {
       throw new InvalidArgumentException(
@@ -121,7 +121,7 @@ abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializab
   public static function fromJson(string $geoJson, int|Srid $srid = 0): static
   {
     $geometry = Factory::parse($geoJson);
-    $geometry->srid = $srid instanceof Srid ? $srid->getValue() : $srid;
+    $geometry->srid = $srid instanceof Srid ? $srid->value : $srid;
 
     if (! ($geometry instanceof static)) {
       throw new InvalidArgumentException(

--- a/src/Objects/GeometryCollection.php
+++ b/src/Objects/GeometryCollection.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use MatanYadaev\EloquentSpatial\Enums\Srid;
 
 class GeometryCollection extends Geometry implements ArrayAccess
 {
@@ -24,14 +25,14 @@ class GeometryCollection extends Geometry implements ArrayAccess
    *
    * @throws InvalidArgumentException
    */
-  public function __construct(Collection|array $geometries, int $srid = 0)
+  public function __construct(Collection|array $geometries, int|Srid $srid = 0)
   {
     if (is_array($geometries)) {
       $geometries = collect($geometries);
     }
 
     $this->geometries = $geometries;
-    $this->srid = $srid;
+    $this->srid = $srid instanceof Srid ? $srid->value : $srid;
 
     $this->validateGeometriesType();
     $this->validateGeometriesCount();

--- a/src/Objects/MultiLineString.php
+++ b/src/Objects/MultiLineString.php
@@ -6,6 +6,7 @@ namespace MatanYadaev\EloquentSpatial\Objects;
 
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use MatanYadaev\EloquentSpatial\Enums\Srid;
 
 /**
  * @property Collection<int, LineString> $geometries
@@ -26,10 +27,10 @@ class MultiLineString extends GeometryCollection
    *
    * @throws InvalidArgumentException
    */
-  public function __construct(Collection|array $geometries, int $srid = 0)
+  public function __construct(Collection|array $geometries, int|Srid $srid = 0)
   {
     // @phpstan-ignore-next-line
-    parent::__construct($geometries, $srid);
+    parent::__construct($geometries, $this->srid = $srid instanceof Srid ? $srid->value : $srid);
   }
 
   public function toWkt(): string

--- a/src/Objects/MultiPolygon.php
+++ b/src/Objects/MultiPolygon.php
@@ -6,6 +6,7 @@ namespace MatanYadaev\EloquentSpatial\Objects;
 
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use MatanYadaev\EloquentSpatial\Enums\Srid;
 
 /**
  * @property Collection<int, Polygon> $geometries
@@ -26,10 +27,10 @@ class MultiPolygon extends GeometryCollection
    *
    * @throws InvalidArgumentException
    */
-  public function __construct(Collection|array $geometries, int $srid = 0)
+  public function __construct(Collection|array $geometries, int|Srid $srid = 0)
   {
     // @phpstan-ignore-next-line
-    parent::__construct($geometries, $srid);
+    parent::__construct($geometries, $this->srid = $srid instanceof Srid ? $srid->value : $srid);
   }
 
   public function toWkt(): string

--- a/src/Objects/Point.php
+++ b/src/Objects/Point.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace MatanYadaev\EloquentSpatial\Objects;
 
+use MatanYadaev\EloquentSpatial\Enums\Srid;
+
 class Point extends Geometry
 {
   public float $latitude;
 
   public float $longitude;
 
-  public function __construct(float $latitude, float $longitude, int $srid = 0)
+  public function __construct(float $latitude, float $longitude, int|Srid $srid = 0)
   {
     $this->latitude = $latitude;
     $this->longitude = $longitude;
-    $this->srid = $srid;
+    $this->srid = $srid instanceof Srid ? $srid->value : $srid;
   }
 
   public function toWkt(): string

--- a/src/Objects/PointCollection.php
+++ b/src/Objects/PointCollection.php
@@ -6,6 +6,7 @@ namespace MatanYadaev\EloquentSpatial\Objects;
 
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use MatanYadaev\EloquentSpatial\Enums\Srid;
 
 /**
  * @property Collection<int, Point> $geometries
@@ -24,9 +25,9 @@ abstract class PointCollection extends GeometryCollection
    *
    * @throws InvalidArgumentException
    */
-  public function __construct(Collection|array $geometries, int $srid = 0)
+  public function __construct(Collection|array $geometries, int|Srid $srid = 0)
   {
     // @phpstan-ignore-next-line
-    parent::__construct($geometries, $srid);
+    parent::__construct($geometries, $this->srid = $srid instanceof Srid ? $srid->value : $srid);
   }
 }

--- a/tests/Objects/GeometryCollectionTest.php
+++ b/tests/Objects/GeometryCollectionTest.php
@@ -32,7 +32,7 @@ it('creates a model record with geometry collection', function (): void {
   expect($testPlace->geometry_collection)->toEqual($geometryCollection);
 });
 
-it('creates a model record with geometry collection with SRID', function (): void {
+it('creates a model record with geometry collection with SRID integer', function (): void {
   $geometryCollection = new GeometryCollection([
     new Polygon([
       new LineString([
@@ -45,6 +45,26 @@ it('creates a model record with geometry collection with SRID', function (): voi
     ]),
     new Point(0, 180),
   ], Srid::WGS84->value);
+
+  /** @var TestPlace $testPlace */
+  $testPlace = TestPlace::factory()->create(['geometry_collection' => $geometryCollection]);
+
+  expect($testPlace->geometry_collection->srid)->toBe(Srid::WGS84->value);
+});
+
+it('creates a model record with geometry collection with SRID enum', function (): void {
+  $geometryCollection = new GeometryCollection([
+    new Polygon([
+      new LineString([
+        new Point(0, 180),
+        new Point(1, 179),
+        new Point(2, 178),
+        new Point(3, 177),
+        new Point(0, 180),
+      ]),
+    ]),
+    new Point(0, 180),
+  ], Srid::WGS84);
 
   /** @var TestPlace $testPlace */
   $testPlace = TestPlace::factory()->create(['geometry_collection' => $geometryCollection]);

--- a/tests/Objects/LineStringTest.php
+++ b/tests/Objects/LineStringTest.php
@@ -23,11 +23,23 @@ it('creates a model record with line string', function (): void {
   expect($testPlace->line_string)->toEqual($lineString);
 });
 
-it('creates a model record with line string with SRID', function (): void {
+it('creates a model record with line string with SRID integer', function (): void {
   $lineString = new LineString([
     new Point(0, 180),
     new Point(1, 179),
   ], Srid::WGS84->value);
+
+  /** @var TestPlace $testPlace */
+  $testPlace = TestPlace::factory()->create(['line_string' => $lineString]);
+
+  expect($testPlace->line_string->srid)->toBe(Srid::WGS84->value);
+});
+
+it('creates a model record with line string with SRID enum', function (): void {
+  $lineString = new LineString([
+    new Point(0, 180),
+    new Point(1, 179),
+  ], Srid::WGS84);
 
   /** @var TestPlace $testPlace */
   $testPlace = TestPlace::factory()->create(['line_string' => $lineString]);

--- a/tests/Objects/MultiLineStringTest.php
+++ b/tests/Objects/MultiLineStringTest.php
@@ -25,13 +25,27 @@ it('creates a model record with multi line string', function (): void {
   expect($testPlace->multi_line_string)->toEqual($multiLineString);
 });
 
-it('creates a model record with multi line string with SRID', function (): void {
+it('creates a model record with multi line string with SRID integer', function (): void {
   $multiLineString = new MultiLineString([
     new LineString([
       new Point(0, 180),
       new Point(1, 179),
     ]),
   ], Srid::WGS84->value);
+
+  /** @var TestPlace $testPlace */
+  $testPlace = TestPlace::factory()->create(['multi_line_string' => $multiLineString]);
+
+  expect($testPlace->multi_line_string->srid)->toBe(Srid::WGS84->value);
+});
+
+it('creates a model record with multi line string with SRID enum', function (): void {
+  $multiLineString = new MultiLineString([
+    new LineString([
+      new Point(0, 180),
+      new Point(1, 179),
+    ]),
+  ], Srid::WGS84);
 
   /** @var TestPlace $testPlace */
   $testPlace = TestPlace::factory()->create(['multi_line_string' => $multiLineString]);

--- a/tests/Objects/MultiPointTest.php
+++ b/tests/Objects/MultiPointTest.php
@@ -22,10 +22,21 @@ it('creates a model record with multi point', function (): void {
   expect($testPlace->multi_point)->toEqual($multiPoint);
 });
 
-it('creates a model record with multi point with SRID', function (): void {
+it('creates a model record with multi point with SRID integer', function (): void {
   $multiPoint = new MultiPoint([
     new Point(0, 180),
   ], Srid::WGS84->value);
+
+  /** @var TestPlace $testPlace */
+  $testPlace = TestPlace::factory()->create(['multi_point' => $multiPoint]);
+
+  expect($testPlace->multi_point->srid)->toBe(Srid::WGS84->value);
+});
+
+it('creates a model record with multi point with SRID enum', function (): void {
+  $multiPoint = new MultiPoint([
+    new Point(0, 180),
+  ], Srid::WGS84);
 
   /** @var TestPlace $testPlace */
   $testPlace = TestPlace::factory()->create(['multi_point' => $multiPoint]);

--- a/tests/Objects/MultiPolygonTest.php
+++ b/tests/Objects/MultiPolygonTest.php
@@ -31,7 +31,7 @@ it('creates a model record with multi polygon', function (): void {
   expect($testPlace->multi_polygon)->toEqual($multiPolygon);
 });
 
-it('creates a model record with multi polygon with SRID', function (): void {
+it('creates a model record with multi polygon with SRID integer', function (): void {
   $multiPolygon = new MultiPolygon([
     new Polygon([
       new LineString([
@@ -43,6 +43,25 @@ it('creates a model record with multi polygon with SRID', function (): void {
       ]),
     ]),
   ], Srid::WGS84->value);
+
+  /** @var TestPlace $testPlace */
+  $testPlace = TestPlace::factory()->create(['multi_polygon' => $multiPolygon]);
+
+  expect($testPlace->multi_polygon->srid)->toBe(Srid::WGS84->value);
+});
+
+it('creates a model record with multi polygon with SRID enum', function (): void {
+  $multiPolygon = new MultiPolygon([
+    new Polygon([
+      new LineString([
+        new Point(0, 180),
+        new Point(1, 179),
+        new Point(2, 178),
+        new Point(3, 177),
+        new Point(0, 180),
+      ]),
+    ]),
+  ], Srid::WGS84);
 
   /** @var TestPlace $testPlace */
   $testPlace = TestPlace::factory()->create(['multi_polygon' => $multiPolygon]);

--- a/tests/Objects/PointTest.php
+++ b/tests/Objects/PointTest.php
@@ -18,8 +18,17 @@ it('creates a model record with point', function (): void {
   expect($testPlace->point)->toEqual($point);
 });
 
-it('creates a model record with point with SRID', function (): void {
+it('creates a model record with point with SRID integer', function (): void {
   $point = new Point(0, 180, Srid::WGS84->value);
+
+  /** @var TestPlace $testPlace */
+  $testPlace = TestPlace::factory()->create(['point' => $point]);
+
+  expect($testPlace->point->srid)->toBe(Srid::WGS84->value);
+});
+
+it('creates a model record with point with SRID enum', function (): void {
+  $point = new Point(0, 180, Srid::WGS84);
 
   /** @var TestPlace $testPlace */
   $testPlace = TestPlace::factory()->create(['point' => $point]);

--- a/tests/Objects/PolygonTest.php
+++ b/tests/Objects/PolygonTest.php
@@ -28,7 +28,7 @@ it('creates a model record with polygon', function (): void {
   expect($testPlace->polygon)->toEqual($polygon);
 });
 
-it('creates a model record with polygon with SRID', function (): void {
+it('creates a model record with polygon with SRID integer', function (): void {
   $polygon = new Polygon([
     new LineString([
       new Point(0, 180),
@@ -38,6 +38,23 @@ it('creates a model record with polygon with SRID', function (): void {
       new Point(0, 180),
     ]),
   ], Srid::WGS84->value);
+
+  /** @var TestPlace $testPlace */
+  $testPlace = TestPlace::factory()->create(['polygon' => $polygon]);
+
+  expect($testPlace->polygon->srid)->toBe(Srid::WGS84->value);
+});
+
+it('creates a model record with polygon with SRID enum', function (): void {
+  $polygon = new Polygon([
+    new LineString([
+      new Point(0, 180),
+      new Point(1, 179),
+      new Point(2, 178),
+      new Point(3, 177),
+      new Point(0, 180),
+    ]),
+  ], Srid::WGS84);
 
   /** @var TestPlace $testPlace */
   $testPlace = TestPlace::factory()->create(['polygon' => $polygon]);


### PR DESCRIPTION
Small PR that adds the Srid enum as a valid property to the object constructors as srid property.
This change allows users to just pass the enum to the constructor instead of having to call '->value' themselves.