### PR TITLE
fix AxisOrder incompatible with Postgres (PostGIS)

### DIFF
--- a/src/AxisOrder.php
+++ b/src/AxisOrder.php
@@ -4,44 +4,49 @@ declare(strict_types=1);
 
 namespace MatanYadaev\EloquentSpatial;
 
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\MySqlConnection;
 use PDO;
 
 class AxisOrder
 {
-  public function __construct()
-  {
-  }
-
-  public function supported(ConnectionInterface $connection): bool
-  {
-    /** @var MySqlConnection $connection */
-    if ($this->isMariaDb($connection)) {
-      // @codeCoverageIgnoreStart
-      return false;
-      // @codeCoverageIgnoreEnd
+    public function __construct()
+    {
     }
 
-    if ($this->isMySql57($connection)) {
-      // @codeCoverageIgnoreStart
-      return false;
-      // @codeCoverageIgnoreEnd
+    public function supported(ConnectionInterface $connection): bool
+    {
+        if (! $connection instanceof MySqlConnection) {
+          return false;
+        }
+
+        /** @var MySqlConnection $connection */
+        if ($this->isMariaDb($connection)) {
+            // @codeCoverageIgnoreStart
+            return false;
+            // @codeCoverageIgnoreEnd
+        }
+
+        if ($this->isMySql57($connection)) {
+            // @codeCoverageIgnoreStart
+            return false;
+            // @codeCoverageIgnoreEnd
+        }
+
+        return true;
     }
 
-    return true;
-  }
+    private function isMariaDb(MySqlConnection $connection): bool
+    {
+        return $connection->isMaria();
+    }
 
-  private function isMariaDb(MySqlConnection $connection): bool
-  {
-    return $connection->isMaria();
-  }
+    private function isMySql57(MySqlConnection $connection): bool
+    {
+        /** @var string $version */
+        $version = $connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-  private function isMySql57(MySqlConnection $connection): bool
-  {
-    /** @var string $version */
-    $version = $connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
-
-    return version_compare($version, '5.8.0', '<');
-  }
+        return version_compare($version, '5.8.0', '<');
+    }
 }

--- a/src/GeometryCast.php
+++ b/src/GeometryCast.php
@@ -44,7 +44,7 @@ class GeometryCast implements CastsAttributes
       return $this->className::fromWkt($wkt, $srid);
     }
 
-    return $this->className::fromWkb($value);
+    return $this->className::fromWkb($value, $model->getConnection());
   }
 
   /**

--- a/src/Objects/Geometry.php
+++ b/src/Objects/Geometry.php
@@ -66,20 +66,25 @@ abstract class Geometry implements Castable, Arrayable, Jsonable, JsonSerializab
 
   /**
    * @param  string  $wkb
+   * @param  ConnectionInterface  $connection
    * @return static
    *
    * @throws InvalidArgumentException
    */
-  public static function fromWkb(string $wkb): static
+  public static function fromWkb(string $wkb, ConnectionInterface $connection): static
   {
-    $srid = substr($wkb, 0, 4);
-    // @phpstan-ignore-next-line
-    $srid = unpack('L', $srid)[1];
+    if ($connection instanceof PostgresConnection) {
+      $geometry = Factory::parse($wkb);
+    } else {
+      $srid = substr($wkb, 0, 4);
+      // @phpstan-ignore-next-line
+      $srid = unpack('L', $srid)[1];
 
-    $wkb = substr($wkb, 4);
+      $wkb = substr($wkb, 4);
 
-    $geometry = Factory::parse($wkb);
-    $geometry->srid = $srid;
+      $geometry = Factory::parse($wkb);
+      $geometry->srid = $srid;
+    }
 
     if (! ($geometry instanceof static)) {
       throw new InvalidArgumentException(


### PR DESCRIPTION
I believe this is the only fix to do in order to make this package work fully on Postgres (with PostGIS extension installed and enabled)

I don't know about other drivers, maybe making a match to cover all the rest, but as I only use MySQL and now PostgreSQL I have no idea about MSSQL which is the only one left