### PR TITLE
Fix SRID not being optional for expression in GeometryCast

### DIFF
--- a/tests/GeometryCastTest.php
+++ b/tests/GeometryCastTest.php
@@ -217,4 +217,3 @@ it('handles ST_GeomFromText option for mysql on a raw expression', function (): 
     // Will trigger 'point' attribute to cast raw expression to a Point object
     expect($testPlace->isDirty())->toBeTrue();
 })->skip(fn () => ! AxisOrder::supported(DB::connection()));
-

--- a/tests/GeometryCastTest.php
+++ b/tests/GeometryCastTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\DB;
+use MatanYadaev\EloquentSpatial\AxisOrder;
 use MatanYadaev\EloquentSpatial\Enums\Srid;
 use MatanYadaev\EloquentSpatial\GeometryExpression;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
@@ -189,3 +190,31 @@ it('checks a model record is not dirty after update to same value before save', 
 
     expect($testPlace->isDirty())->toBeFalse();
 });
+
+it('handles ST_GeomFromText optional values on a raw expression', function (string $expression): void {
+    // Arrange
+    $testPlace = TestPlace::factory()->create(['point' => DB::raw($expression)]);
+
+    // Act
+    $testPlace->point = null;
+
+    // Assert
+    // Will trigger 'point' attribute to cast raw expression to a Point object
+    expect($testPlace->isDirty())->toBeTrue();
+})->with([
+    'without SRID' => "ST_GeomFromText('POINT(12.38057 55.73406)')",
+    'with SRID' => "ST_GeomFromText('POINT(12.38057 55.73406)', 4326)",
+]);
+
+it('handles ST_GeomFromText option for mysql on a raw expression', function (): void {
+    // Arrange
+    $testPlace = TestPlace::factory()->create(['point' => DB::raw("ST_GeomFromText('POINT(12.38057 55.73406)', 4326, 'axis-order=long-lat')")]);
+
+    // Act
+    $testPlace->point = null;
+
+    // Assert
+    // Will trigger 'point' attribute to cast raw expression to a Point object
+    expect($testPlace->isDirty())->toBeTrue();
+})->skip(fn () => ! AxisOrder::supported(DB::connection()));
+


### PR DESCRIPTION
The current implementation of GeometryCast requires SRID to present in the expression when setting an model attribute with `DB:raw`  

The given case:
```php
$place = Place::factory()->create(['point' => DB::raw("ST_GeomFromText('POINT(12.38057 55.73406)')")]);
$place->isDirty()
   ```
This will throw the following error because the regex looks for a SRID in the expressionValue
```
  Undefined array key 1

  at src\GeometryCast.php:86
     82▕         $expressionValue = $expression->getValue($grammar);
     83▕ 
     84▕         preg_match('/ST_GeomFromText\(\'(.+)\', .+(, .+)?\)/', (string) $expressionValue, $match);
     85▕ 
  ➜ 86▕         return $match[1];
     87▕     }
     88▕ 
     89▕     private function extractSridFromExpression(ExpressionContract $expression, Connection $connection): int
     90▕     {
```


The `ST_GeomFromText` specifications allows SRID not to be specified as seen in mysql and PostGis documentation:
* [Mysql](https://dev.mysql.com/doc/refman/8.4/en/gis-wkt-functions.html#function_st-geomfromtext) 
* [PostGIS](https://postgis.net/docs/ST_GeomFromText.html)


I have adjusted GeometryCast regex treat SRID as an optional parameter and return 0 when SRID is not defined.