### PR TITLE
Support Geometry class extension

### DIFF
--- a/.run/Test - MySQL.run.xml
+++ b/.run/Test - MySQL.run.xml
@@ -1,7 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="Test - MySQL 8.0" type="PestRunConfigurationType">
+    <configuration default="false" name="Test - MySQL" type="PestRunConfigurationType">
         <CommandLine>
             <envs>
+                <env name="DB_COLLATION" value="utf8mb4_unicode_ci"/>
+                <env name="DB_CONNECTION" value="mysql"/>
                 <env name="DB_PORT" value="3307"/>
             </envs>
         </CommandLine>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 All notable changes to `laravel-eloquent-spatial` will be documented in this file.
 
-## v4.2.1 - 2024-04-02
-
-### What's Changed
-
-* `Geometry::fromArray` added optional`$srid` paramter by @ju-gow in https://github.com/MatanYadaev/laravel-eloquent-spatial/pull/118
-
-### New Contributors
-
-* @ju-gow made their first contribution in https://github.com/MatanYadaev/laravel-eloquent-spatial/pull/118
-
-**Full Changelog**: https://github.com/MatanYadaev/laravel-eloquent-spatial/compare/4.2.0...4.2.1
-
 ## v4.2.0 - 2024-03-13
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -152,6 +152,48 @@ For more comprehensive documentation on the API, please refer to the [API](API.m
 
 ## Extension
 
+### Extend with custom geometry classes
+
+You can extend the geometry classes by creating custom geometry classes and add or overwrite certain functionality.
+
+Here's an example how to overwrite the `toArray()` method by adding array keys to the `coordinates` array and removing the `type` key. 
+
+```php
+use MatanYadaev\EloquentSpatial\Objects\Point as EloquentSpatialPoint;
+
+class Point extends EloquentSpatialPoint
+{
+    public function toArray(): array
+    {
+        return [
+            'coordinates' => [
+                'longitude' => $this->longitude,
+                'latitude' => $this->latitude,
+            ],
+        ];
+    }
+}
+```
+
+All we have to do is tell the package that we want to use are our custom Point class, we can do this in the AppServiceProvider under the `boot()` method.
+
+```php
+use App\ValueObjects\Point;
+use Illuminate\Support\ServiceProvider;
+use MatanYadaev\EloquentSpatial\EloquentSpatial;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        EloquentSpatial::usePoint(Point::class);
+    }
+}
+```
+
+
+### Extend Geometry class with macros
+
 You can add new methods to the `Geometry` class through macros.
 
 Here's an example of how to register a macro in your service provider's `boot` method:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,25 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
+Update your model to use the custom geometry class in the `casts()` method
+
+```php
+use App\ValueObjects\Point;
+use Illuminate\Database\Eloquent\Model;
+use MatanYadaev\EloquentSpatial\Traits\HasSpatial;
+
+class Location extends Model
+{
+    use HasSpatial;
+
+    protected function casts(): array
+    {
+        return [
+            'coordinates' => Point::class,
+        ];
+    }
+}
+```
 
 ### Extend Geometry class with macros
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,7 +18,8 @@ parameters:
     -
       message: '#Call to an undefined method Pest\\Expectation\<.+\>\:\:toBe(InstanceOf)?On(Postgres|Mysql)\(\)#'
       path: tests/*.php
+    -
+      identifier: missingType.generics
 
   level: max
   checkMissingIterableValueType: true
-  checkGenericClassInNonGenericObjectType: false

--- a/src/EloquentSpatial.php
+++ b/src/EloquentSpatial.php
@@ -14,29 +14,29 @@ use MatanYadaev\EloquentSpatial\Objects\Polygon;
 
 class EloquentSpatial
 {
-    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\GeometryCollection> */
+    /** @var class-string<GeometryCollection> */
     public static string $geometryCollection = GeometryCollection::class;
 
-    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\LineString> */
+    /** @var class-string<LineString> */
     public static string $lineString = LineString::class;
 
-    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\MultiLineString> */
+    /** @var class-string<MultiLineString> */
     public static string $multiLineString = MultiLineString::class;
 
-    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPoint> */
+    /** @var class-string<MultiPoint> */
     public static string $multiPoint = MultiPoint::class;
 
-    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPolygon> */
+    /** @var class-string<MultiPolygon> */
     public static string $multiPolygon = MultiPolygon::class;
 
-    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\Point> */
+    /** @var class-string<Point> */
     public static string $point = Point::class;
 
-    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\Polygon> */
+    /** @var class-string<Polygon> */
     public static string $polygon = Polygon::class;
 
     /**
-     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\GeometryCollection>  $class
+     * @param  class-string<GeometryCollection>  $class
      */
     public static function useGeometryCollection(string $class): string
     {
@@ -46,7 +46,7 @@ class EloquentSpatial
     }
 
     /**
-     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\LineString>  $class
+     * @param  class-string<LineString>  $class
      */
     public static function useLineString(string $class): string
     {
@@ -56,7 +56,7 @@ class EloquentSpatial
     }
 
     /**
-     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\MultiLineString>  $class
+     * @param  class-string<MultiLineString>  $class
      */
     public static function useMultiLineString(string $class): string
     {
@@ -66,7 +66,7 @@ class EloquentSpatial
     }
 
     /**
-     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPoint>  $class
+     * @param  class-string<MultiPoint>  $class
      */
     public static function useMultiPoint(string $class): string
     {
@@ -76,7 +76,7 @@ class EloquentSpatial
     }
 
     /**
-     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPolygon>  $class
+     * @param  class-string<MultiPolygon>  $class
      */
     public static function useMultiPolygon(string $class): string
     {
@@ -86,7 +86,7 @@ class EloquentSpatial
     }
 
     /**
-     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\Point>  $class
+     * @param  class-string<Point>  $class
      */
     public static function usePoint(string $class): string
     {
@@ -96,7 +96,7 @@ class EloquentSpatial
     }
 
     /**
-     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\Polygon>  $class
+     * @param  class-string<Polygon>  $class
      */
     public static function usePolygon(string $class): string
     {

--- a/src/EloquentSpatial.php
+++ b/src/EloquentSpatial.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatanYadaev\EloquentSpatial;
+
+use MatanYadaev\EloquentSpatial\Objects\GeometryCollection;
+use MatanYadaev\EloquentSpatial\Objects\LineString;
+use MatanYadaev\EloquentSpatial\Objects\MultiLineString;
+use MatanYadaev\EloquentSpatial\Objects\MultiPoint;
+use MatanYadaev\EloquentSpatial\Objects\MultiPolygon;
+use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Objects\Polygon;
+
+class EloquentSpatial
+{
+    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\GeometryCollection> */
+    public static string $geometryCollection = GeometryCollection::class;
+
+    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\LineString> */
+    public static string $lineString = LineString::class;
+
+    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\MultiLineString> */
+    public static string $multiLineString = MultiLineString::class;
+
+    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPoint> */
+    public static string $multiPoint = MultiPoint::class;
+
+    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPolygon> */
+    public static string $multiPolygon = MultiPolygon::class;
+
+    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\Point> */
+    public static string $point = Point::class;
+
+    /** @var class-string<\MatanYadaev\EloquentSpatial\Objects\Polygon> */
+    public static string $polygon = Polygon::class;
+
+    /**
+     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\GeometryCollection>  $class
+     */
+    public static function useGeometryCollection(string $class): string
+    {
+        static::$geometryCollection = $class;
+
+        return static::$geometryCollection;
+    }
+
+    /**
+     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\LineString>  $class
+     */
+    public static function useLineString(string $class): string
+    {
+        static::$lineString = $class;
+
+        return static::$lineString;
+    }
+
+    /**
+     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\MultiLineString>  $class
+     */
+    public static function useMultiLineString(string $class): string
+    {
+        static::$multiLineString = $class;
+
+        return static::$multiLineString;
+    }
+
+    /**
+     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPoint>  $class
+     */
+    public static function useMultiPoint(string $class): string
+    {
+        static::$multiPoint = $class;
+
+        return static::$multiPoint;
+    }
+
+    /**
+     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\MultiPolygon>  $class
+     */
+    public static function useMultiPolygon(string $class): string
+    {
+        static::$multiPolygon = $class;
+
+        return static::$multiPolygon;
+    }
+
+    /**
+     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\Point>  $class
+     */
+    public static function usePoint(string $class): string
+    {
+        static::$point = $class;
+
+        return static::$point;
+    }
+
+    /**
+     * @param  class-string<\MatanYadaev\EloquentSpatial\Objects\Polygon>  $class
+     */
+    public static function usePolygon(string $class): string
+    {
+        static::$polygon = $class;
+
+        return static::$polygon;
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -10,13 +10,6 @@ use geoPHP;
 use InvalidArgumentException;
 use LineString as geoPHPLineString;
 use MatanYadaev\EloquentSpatial\Objects\Geometry;
-use MatanYadaev\EloquentSpatial\Objects\GeometryCollection;
-use MatanYadaev\EloquentSpatial\Objects\LineString;
-use MatanYadaev\EloquentSpatial\Objects\MultiLineString;
-use MatanYadaev\EloquentSpatial\Objects\MultiPoint;
-use MatanYadaev\EloquentSpatial\Objects\MultiPolygon;
-use MatanYadaev\EloquentSpatial\Objects\Point;
-use MatanYadaev\EloquentSpatial\Objects\Polygon;
 use MultiLineString as geoPHPMultiLineString;
 use MultiPoint as geoPHPMultiPoint;
 use MultiPolygon as geoPHPMultiPolygon;
@@ -48,7 +41,7 @@ class Factory
                 throw new InvalidArgumentException('Invalid spatial value');
             }
 
-            return new Point($geometry->coords[1], $geometry->coords[0], $srid);
+            return new EloquentSpatial::$point($geometry->coords[1], $geometry->coords[0], $srid);
         }
 
         /** @var geoPHPGeometryCollection $geometry */
@@ -58,25 +51,25 @@ class Factory
             });
 
         if ($geometry::class === geoPHPMultiPoint::class) {
-            return new MultiPoint($components, $srid);
+            return new EloquentSpatial::$multiPoint($components, $srid);
         }
 
         if ($geometry::class === geoPHPLineString::class) {
-            return new LineString($components, $srid);
+            return new EloquentSpatial::$lineString($components, $srid);
         }
 
         if ($geometry::class === geoPHPPolygon::class) {
-            return new Polygon($components, $srid);
+            return new EloquentSpatial::$polygon($components, $srid);
         }
 
         if ($geometry::class === geoPHPMultiLineString::class) {
-            return new MultiLineString($components, $srid);
+            return new EloquentSpatial::$multiLineString($components, $srid);
         }
 
         if ($geometry::class === geoPHPMultiPolygon::class) {
-            return new MultiPolygon($components, $srid);
+            return new EloquentSpatial::$multiPolygon($components, $srid);
         }
 
-        return new GeometryCollection($components, $srid);
+        return new EloquentSpatial::$geometryCollection($components, $srid);
     }
 }

--- a/src/GeometryCast.php
+++ b/src/GeometryCast.php
@@ -66,7 +66,7 @@ class GeometryCast implements CastsAttributes
             return $value;
         }
 
-        if (! ($value instanceof $this->className)) {
+        if (! ($value instanceof $this->className) || get_class($value) !== $this->className) {
             $geometryType = is_object($value) ? $value::class : gettype($value);
             throw new InvalidArgumentException(
                 sprintf('Expected %s, %s given.', $this->className, $geometryType)

--- a/src/GeometryExpression.php
+++ b/src/GeometryExpression.php
@@ -10,9 +10,7 @@ use Illuminate\Database\PostgresConnection;
 /** @codeCoverageIgnore */
 class GeometryExpression
 {
-    public function __construct(readonly private string $expression)
-    {
-    }
+    public function __construct(readonly private string $expression) {}
 
     public function normalize(ConnectionInterface $connection): string
     {

--- a/src/GeometryExpression.php
+++ b/src/GeometryExpression.php
@@ -10,7 +10,9 @@ use Illuminate\Database\PostgresConnection;
 /** @codeCoverageIgnore */
 class GeometryExpression
 {
-    public function __construct(readonly private string $expression) {}
+    public function __construct(readonly private string $expression)
+    {
+    }
 
     public function normalize(ConnectionInterface $connection): string
     {

--- a/tests/HasSpatialTest.php
+++ b/tests/HasSpatialTest.php
@@ -447,7 +447,7 @@ it('uses spatial function with expression', function (): void {
 });
 
 it('toExpressionString can handle a Expression input', function (): void {
-    $spatialBuilder = new TestPlace();
+    $spatialBuilder = new TestPlace;
     $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
     $result = $toExpressionStringMethod->invoke($spatialBuilder, DB::raw('POINT(longitude, latitude)'));
@@ -456,7 +456,7 @@ it('toExpressionString can handle a Expression input', function (): void {
 });
 
 it('toExpressionString can handle a Geometry input', function (): void {
-    $testPlace = new TestPlace();
+    $testPlace = new TestPlace;
     $toExpressionStringMethod = (new ReflectionClass($testPlace))->getMethod('toExpressionString');
     $polygon = Polygon::fromJson('{"type":"Polygon","coordinates":[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]}');
 
@@ -469,7 +469,7 @@ it('toExpressionString can handle a Geometry input', function (): void {
 });
 
 it('toExpressionString can handle a string input', function (): void {
-    $spatialBuilder = new TestPlace();
+    $spatialBuilder = new TestPlace;
     $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
     $result = $toExpressionStringMethod->invoke($spatialBuilder, 'test_places.point');

--- a/tests/HasSpatialTest.php
+++ b/tests/HasSpatialTest.php
@@ -447,7 +447,7 @@ it('uses spatial function with expression', function (): void {
 });
 
 it('toExpressionString can handle a Expression input', function (): void {
-    $spatialBuilder = new TestPlace;
+    $spatialBuilder = new TestPlace();
     $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
     $result = $toExpressionStringMethod->invoke($spatialBuilder, DB::raw('POINT(longitude, latitude)'));
@@ -456,7 +456,7 @@ it('toExpressionString can handle a Expression input', function (): void {
 });
 
 it('toExpressionString can handle a Geometry input', function (): void {
-    $testPlace = new TestPlace;
+    $testPlace = new TestPlace();
     $toExpressionStringMethod = (new ReflectionClass($testPlace))->getMethod('toExpressionString');
     $polygon = Polygon::fromJson('{"type":"Polygon","coordinates":[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]}');
 
@@ -469,7 +469,7 @@ it('toExpressionString can handle a Geometry input', function (): void {
 });
 
 it('toExpressionString can handle a string input', function (): void {
-    $spatialBuilder = new TestPlace;
+    $spatialBuilder = new TestPlace();
     $toExpressionStringMethod = (new ReflectionClass($spatialBuilder))->getMethod('toExpressionString');
 
     $result = $toExpressionStringMethod->invoke($spatialBuilder, 'test_places.point');

--- a/tests/Objects/GeometryCollectionTest.php
+++ b/tests/Objects/GeometryCollectionTest.php
@@ -486,7 +486,6 @@ it('casts a GeometryCollection to a string', function (): void {
 it('adds a macro toGeometryCollection', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
-        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 

--- a/tests/Objects/GeometryTest.php
+++ b/tests/Objects/GeometryTest.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\QueryException;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Facades\DB;
 use MatanYadaev\EloquentSpatial\AxisOrder;
 use MatanYadaev\EloquentSpatial\Enums\Srid;
@@ -11,8 +10,6 @@ use MatanYadaev\EloquentSpatial\Objects\Geometry;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 use MatanYadaev\EloquentSpatial\Objects\Point;
 use MatanYadaev\EloquentSpatial\Tests\TestModels\TestPlace;
-
-uses(DatabaseMigrations::class);
 
 it('throws exception when generating geometry from other geometry WKB', function (): void {
     expect(function (): void {

--- a/tests/Objects/GeometryTest.php
+++ b/tests/Objects/GeometryTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Facades\DB;
 use MatanYadaev\EloquentSpatial\AxisOrder;
 use MatanYadaev\EloquentSpatial\Enums\Srid;
@@ -10,6 +11,8 @@ use MatanYadaev\EloquentSpatial\Objects\Geometry;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 use MatanYadaev\EloquentSpatial\Objects\Point;
 use MatanYadaev\EloquentSpatial\Tests\TestModels\TestPlace;
+
+uses(DatabaseMigrations::class);
 
 it('throws exception when generating geometry from other geometry WKB', function (): void {
     expect(function (): void {

--- a/tests/Objects/LineStringTest.php
+++ b/tests/Objects/LineStringTest.php
@@ -200,7 +200,6 @@ it('casts a LineString to a string', function (): void {
 it('adds a macro toLineString', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
-        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 

--- a/tests/Objects/LineStringTest.php
+++ b/tests/Objects/LineStringTest.php
@@ -1,11 +1,14 @@
 <?php
 
+use MatanYadaev\EloquentSpatial\EloquentSpatial;
 use MatanYadaev\EloquentSpatial\Enums\Srid;
 use MatanYadaev\EloquentSpatial\Objects\Geometry;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 use MatanYadaev\EloquentSpatial\Objects\Point;
 use MatanYadaev\EloquentSpatial\Objects\Polygon;
+use MatanYadaev\EloquentSpatial\Tests\TestModels\TestExtendedPlace;
 use MatanYadaev\EloquentSpatial\Tests\TestModels\TestPlace;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedLineString;
 
 it('creates a model record with line string', function (): void {
     $lineString = new LineString([
@@ -208,4 +211,32 @@ it('adds a macro toLineString', function (): void {
 
     // @phpstan-ignore-next-line
     expect($lineString->getName())->toBe('LineString');
+});
+
+it('uses an extended LineString class', function (): void {
+    EloquentSpatial::useLineString(ExtendedLineString::class);
+
+    $lineString = new ExtendedLineString([
+        new Point(0, 180),
+        new Point(1, 179),
+    ], 4326);
+
+    /** @var TestExtendedPlace $testPlace */
+    $testPlace = TestExtendedPlace::factory()->create(['line_string' => $lineString])->fresh();
+
+    expect($testPlace->line_string)->toBeInstanceOf(ExtendedLineString::class);
+    expect($testPlace->line_string)->toEqual($lineString);
+});
+
+it('throws exception when storing a record with regular LineString instead of the extended one', function (): void {
+    EloquentSpatial::useLineString(ExtendedLineString::class);
+
+    $lineString = new LineString([
+        new Point(0, 180),
+        new Point(1, 179),
+    ], 4326);
+
+    expect(function () use ($lineString): void {
+        TestExtendedPlace::factory()->create(['line_string' => $lineString]);
+    })->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Objects/MultiLineStringTest.php
+++ b/tests/Objects/MultiLineStringTest.php
@@ -228,6 +228,7 @@ it('casts a MultiLineString to a string', function (): void {
 it('adds a macro toMultiLineString', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
+        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 
@@ -243,8 +244,8 @@ it('adds a macro toMultiLineString', function (): void {
 });
 
 it('uses an extended MultiLineString class', function (): void {
+    // Arrange
     EloquentSpatial::useMultiLineString(ExtendedMultiLineString::class);
-
     $multiLineString = new ExtendedMultiLineString([
         new LineString([
             new Point(0, 180),
@@ -252,16 +253,18 @@ it('uses an extended MultiLineString class', function (): void {
         ]),
     ], 4326);
 
+    // Act
     /** @var TestExtendedPlace $testPlace */
     $testPlace = TestExtendedPlace::factory()->create(['multi_line_string' => $multiLineString])->fresh();
 
+    // Assert
     expect($testPlace->multi_line_string)->toBeInstanceOf(ExtendedMultiLineString::class);
     expect($testPlace->multi_line_string)->toEqual($multiLineString);
 });
 
 it('throws exception when storing a record with regular MultiLineString instead of the extended one', function (): void {
+    // Arrange
     EloquentSpatial::useMultiLineString(ExtendedMultiLineString::class);
-
     $multiLineString = new MultiLineString([
         new LineString([
             new Point(0, 180),
@@ -269,7 +272,24 @@ it('throws exception when storing a record with regular MultiLineString instead 
         ]),
     ], 4326);
 
+    // Act & Assert
     expect(function () use ($multiLineString): void {
         TestExtendedPlace::factory()->create(['multi_line_string' => $multiLineString]);
+    })->toThrow(InvalidArgumentException::class);
+});
+
+it('throws exception when storing a record with extended MultiLineString instead of the regular one', function (): void {
+    // Arrange
+    EloquentSpatial::useMultiLineString(MultiLineString::class);
+    $multiLineString = new ExtendedMultiLineString([
+        new LineString([
+            new Point(0, 180),
+            new Point(1, 179),
+        ]),
+    ], 4326);
+
+    // Act & Assert
+    expect(function () use ($multiLineString): void {
+        TestPlace::factory()->create(['multi_line_string' => $multiLineString]);
     })->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Objects/MultiLineStringTest.php
+++ b/tests/Objects/MultiLineStringTest.php
@@ -228,7 +228,6 @@ it('casts a MultiLineString to a string', function (): void {
 it('adds a macro toMultiLineString', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
-        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 

--- a/tests/Objects/MultiLineStringTest.php
+++ b/tests/Objects/MultiLineStringTest.php
@@ -1,11 +1,14 @@
 <?php
 
+use MatanYadaev\EloquentSpatial\EloquentSpatial;
 use MatanYadaev\EloquentSpatial\Enums\Srid;
 use MatanYadaev\EloquentSpatial\Objects\Geometry;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 use MatanYadaev\EloquentSpatial\Objects\MultiLineString;
 use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Tests\TestModels\TestExtendedPlace;
 use MatanYadaev\EloquentSpatial\Tests\TestModels\TestPlace;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedMultiLineString;
 
 it('creates a model record with multi line string', function (): void {
     $multiLineString = new MultiLineString([
@@ -238,4 +241,36 @@ it('adds a macro toMultiLineString', function (): void {
 
     // @phpstan-ignore-next-line
     expect($multiLineString->getName())->toBe('MultiLineString');
+});
+
+it('uses an extended MultiLineString class', function (): void {
+    EloquentSpatial::useMultiLineString(ExtendedMultiLineString::class);
+
+    $multiLineString = new ExtendedMultiLineString([
+        new LineString([
+            new Point(0, 180),
+            new Point(1, 179),
+        ]),
+    ], 4326);
+
+    /** @var TestExtendedPlace $testPlace */
+    $testPlace = TestExtendedPlace::factory()->create(['multi_line_string' => $multiLineString])->fresh();
+
+    expect($testPlace->multi_line_string)->toBeInstanceOf(ExtendedMultiLineString::class);
+    expect($testPlace->multi_line_string)->toEqual($multiLineString);
+});
+
+it('throws exception when storing a record with regular MultiLineString instead of the extended one', function (): void {
+    EloquentSpatial::useMultiLineString(ExtendedMultiLineString::class);
+
+    $multiLineString = new MultiLineString([
+        new LineString([
+            new Point(0, 180),
+            new Point(1, 179),
+        ]),
+    ], 4326);
+
+    expect(function () use ($multiLineString): void {
+        TestExtendedPlace::factory()->create(['multi_line_string' => $multiLineString]);
+    })->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Objects/MultiPointTest.php
+++ b/tests/Objects/MultiPointTest.php
@@ -183,7 +183,6 @@ it('casts a MultiPoint to a string', function (): void {
 it('adds a macro toMultiPoint', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
-        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 

--- a/tests/Objects/MultiPolygonTest.php
+++ b/tests/Objects/MultiPolygonTest.php
@@ -304,7 +304,6 @@ it('casts a MultiPolygon to a string', function (): void {
 it('adds a macro toMultiPolygon', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
-        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 

--- a/tests/Objects/PointTest.php
+++ b/tests/Objects/PointTest.php
@@ -133,7 +133,6 @@ it('casts a Point to a string', function (): void {
 it('adds a macro toPoint', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
-        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 

--- a/tests/Objects/PointTest.php
+++ b/tests/Objects/PointTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use MatanYadaev\EloquentSpatial\EloquentSpatial;
 use MatanYadaev\EloquentSpatial\Enums\Srid;
 use MatanYadaev\EloquentSpatial\Objects\Geometry;
 use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Tests\TestModels\TestExtendedPlace;
 use MatanYadaev\EloquentSpatial\Tests\TestModels\TestPlace;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedPoint;
 
 it('creates a model record with point', function (): void {
     $point = new Point(0, 180);
@@ -138,4 +141,26 @@ it('adds a macro toPoint', function (): void {
 
     // @phpstan-ignore-next-line
     expect($point->getName())->toBe('Point');
+});
+
+it('uses an extended Point class', function (): void {
+    EloquentSpatial::usePoint(ExtendedPoint::class);
+
+    $point = new ExtendedPoint(0, 180, 4326);
+
+    /** @var TestExtendedPlace $testPlace */
+    $testPlace = TestExtendedPlace::factory()->create(['point' => $point])->fresh();
+
+    expect($testPlace->point)->toBeInstanceOf(ExtendedPoint::class);
+    expect($testPlace->point)->toEqual($point);
+});
+
+it('throws exception when storing a record with regular Point instead of the extended one', function (): void {
+    EloquentSpatial::usePoint(ExtendedPoint::class);
+
+    $point = new Point(0, 180, 4326);
+
+    expect(function () use ($point): void {
+        TestExtendedPlace::factory()->create(['point' => $point]);
+    })->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Objects/PointTest.php
+++ b/tests/Objects/PointTest.php
@@ -133,6 +133,7 @@ it('casts a Point to a string', function (): void {
 it('adds a macro toPoint', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
+        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 
@@ -143,23 +144,37 @@ it('adds a macro toPoint', function (): void {
 });
 
 it('uses an extended Point class', function (): void {
+    // Arrange
     EloquentSpatial::usePoint(ExtendedPoint::class);
-
     $point = new ExtendedPoint(0, 180, 4326);
 
+    // Act
     /** @var TestExtendedPlace $testPlace */
     $testPlace = TestExtendedPlace::factory()->create(['point' => $point])->fresh();
 
+    // Assert
     expect($testPlace->point)->toBeInstanceOf(ExtendedPoint::class);
     expect($testPlace->point)->toEqual($point);
 });
 
 it('throws exception when storing a record with regular Point instead of the extended one', function (): void {
+    // Arrange
     EloquentSpatial::usePoint(ExtendedPoint::class);
-
     $point = new Point(0, 180, 4326);
 
+    // Act & Assert
     expect(function () use ($point): void {
         TestExtendedPlace::factory()->create(['point' => $point]);
+    })->toThrow(InvalidArgumentException::class);
+});
+
+it('throws exception when storing a record with extended Point instead of the regular one', function (): void {
+    // Arrange
+    EloquentSpatial::usePoint(Point::class);
+    $point = new ExtendedPoint(0, 180, 4326);
+
+    // Act & Assert
+    expect(function () use ($point): void {
+        TestPlace::factory()->create(['point' => $point]);
     })->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Objects/PolygonTest.php
+++ b/tests/Objects/PolygonTest.php
@@ -273,7 +273,6 @@ it('casts a Polygon to a string', function (): void {
 it('adds a macro toPolygon', function (): void {
     Geometry::macro('getName', function (): string {
         /** @var Geometry $this */
-        // @phpstan-ignore-next-line
         return class_basename($this);
     });
 

--- a/tests/Objects/PolygonTest.php
+++ b/tests/Objects/PolygonTest.php
@@ -1,11 +1,14 @@
 <?php
 
+use MatanYadaev\EloquentSpatial\EloquentSpatial;
 use MatanYadaev\EloquentSpatial\Enums\Srid;
 use MatanYadaev\EloquentSpatial\Objects\Geometry;
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 use MatanYadaev\EloquentSpatial\Objects\Point;
 use MatanYadaev\EloquentSpatial\Objects\Polygon;
+use MatanYadaev\EloquentSpatial\Tests\TestModels\TestExtendedPlace;
 use MatanYadaev\EloquentSpatial\Tests\TestModels\TestPlace;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedPolygon;
 
 it('creates a model record with polygon', function (): void {
     $polygon = new Polygon([
@@ -286,4 +289,42 @@ it('adds a macro toPolygon', function (): void {
 
     // @phpstan-ignore-next-line
     expect($polygon->getName())->toBe('Polygon');
+});
+
+it('uses an extended Polygon class', function (): void {
+    EloquentSpatial::usePolygon(ExtendedPolygon::class);
+
+    $polygon = new ExtendedPolygon([
+        new LineString([
+            new Point(0, 180),
+            new Point(1, 179),
+            new Point(2, 178),
+            new Point(3, 177),
+            new Point(0, 180),
+        ]),
+    ], 4326);
+
+    /** @var TestExtendedPlace $testPlace */
+    $testPlace = TestExtendedPlace::factory()->create(['polygon' => $polygon])->fresh();
+
+    expect($testPlace->polygon)->toBeInstanceOf(ExtendedPolygon::class);
+    expect($testPlace->polygon)->toEqual($polygon);
+});
+
+it('throws exception when storing a record with regular Polygon instead of the extended one', function (): void {
+    EloquentSpatial::usePolygon(ExtendedPolygon::class);
+
+    $polygon = new Polygon([
+        new LineString([
+            new Point(0, 180),
+            new Point(1, 179),
+            new Point(2, 178),
+            new Point(3, 177),
+            new Point(0, 180),
+        ]),
+    ], 4326);
+
+    expect(function () use ($polygon): void {
+        TestExtendedPlace::factory()->create(['polygon' => $polygon]);
+    })->toThrow(InvalidArgumentException::class);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,15 @@ namespace MatanYadaev\EloquentSpatial\Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use MatanYadaev\EloquentSpatial\EloquentSpatial;
 use MatanYadaev\EloquentSpatial\EloquentSpatialServiceProvider;
+use MatanYadaev\EloquentSpatial\Objects\GeometryCollection;
+use MatanYadaev\EloquentSpatial\Objects\LineString;
+use MatanYadaev\EloquentSpatial\Objects\MultiLineString;
+use MatanYadaev\EloquentSpatial\Objects\MultiPoint;
+use MatanYadaev\EloquentSpatial\Objects\MultiPolygon;
+use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Objects\Polygon;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -12,6 +20,8 @@ class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->resetGeometryClasses();
 
         // @phpstan-ignore-next-line
         if (version_compare(Application::VERSION, '11.0.0', '>=')) {
@@ -29,5 +39,16 @@ class TestCase extends Orchestra
         return [
             EloquentSpatialServiceProvider::class,
         ];
+    }
+
+    protected function resetGeometryClasses(): void
+    {
+        EloquentSpatial::useGeometryCollection(GeometryCollection::class);
+        EloquentSpatial::useLineString(LineString::class);
+        EloquentSpatial::useMultiLineString(MultiLineString::class);
+        EloquentSpatial::useMultiPoint(MultiPoint::class);
+        EloquentSpatial::useMultiPolygon(MultiPolygon::class);
+        EloquentSpatial::usePoint(Point::class);
+        EloquentSpatial::usePolygon(Polygon::class);
     }
 }

--- a/tests/TestFactories/TestExtendedPlaceFactory.php
+++ b/tests/TestFactories/TestExtendedPlaceFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestFactories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use MatanYadaev\EloquentSpatial\Tests\TestModels\TestExtendedPlace;
+
+/**
+ * @extends Factory<TestExtendedPlace>
+ */
+class TestExtendedPlaceFactory extends Factory
+{
+    protected $model = TestExtendedPlace::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->streetName,
+            'address' => $this->faker->address,
+        ];
+    }
+}

--- a/tests/TestModels/TestExtendedPlace.php
+++ b/tests/TestModels/TestExtendedPlace.php
@@ -24,6 +24,7 @@ use MatanYadaev\EloquentSpatial\Traits\HasSpatial;
  * @property ExtendedMultiLineString $multi_line_string
  * @property ExtendedPolygon $polygon
  * @property ExtendedMultiPolygon $multi_polygon
+ *
  * @mixin Model
  */
 class TestExtendedPlace extends Model

--- a/tests/TestModels/TestExtendedPlace.php
+++ b/tests/TestModels/TestExtendedPlace.php
@@ -4,8 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestModels;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use MatanYadaev\EloquentSpatial\Objects\Point;
-use MatanYadaev\EloquentSpatial\Objects\Polygon;
 use MatanYadaev\EloquentSpatial\Tests\TestFactories\TestExtendedPlaceFactory;
 use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedGeometryCollection;
 use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedLineString;

--- a/tests/TestModels/TestExtendedPlace.php
+++ b/tests/TestModels/TestExtendedPlace.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestModels;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Objects\Polygon;
+use MatanYadaev\EloquentSpatial\Tests\TestFactories\TestExtendedPlaceFactory;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedGeometryCollection;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedLineString;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedMultiLineString;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedMultiPoint;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedMultiPolygon;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedPoint;
+use MatanYadaev\EloquentSpatial\Tests\TestObjects\ExtendedPolygon;
+use MatanYadaev\EloquentSpatial\Traits\HasSpatial;
+
+/**
+ * @property ExtendedGeometryCollection $geometry_collection
+ * @property ExtendedPoint $point
+ * @property ExtendedMultiPoint $multi_point
+ * @property ExtendedLineString $line_string
+ * @property ExtendedMultiLineString $multi_line_string
+ * @property ExtendedPolygon $polygon
+ * @property ExtendedMultiPolygon $multi_polygon
+ * @mixin Model
+ */
+class TestExtendedPlace extends Model
+{
+    use HasFactory;
+    use HasSpatial;
+
+    protected $casts = [
+        'geometry_collection' => ExtendedGeometryCollection::class,
+        'line_string' => ExtendedLineString::class,
+        'multi_line_string' => ExtendedMultiLineString::class,
+        'multi_point' => ExtendedMultiPoint::class,
+        'multi_polygon' => ExtendedMultiPolygon::class,
+        'point' => ExtendedPoint::class,
+        'polygon' => ExtendedPolygon::class,
+    ];
+
+    protected static function newFactory(): TestExtendedPlaceFactory
+    {
+        return TestExtendedPlaceFactory::new();
+    }
+}

--- a/tests/TestObjects/ExtendedGeometryCollection.php
+++ b/tests/TestObjects/ExtendedGeometryCollection.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
+
+use MatanYadaev\EloquentSpatial\Objects\GeometryCollection;
+
+class ExtendedGeometryCollection extends GeometryCollection {}

--- a/tests/TestObjects/ExtendedGeometryCollection.php
+++ b/tests/TestObjects/ExtendedGeometryCollection.php
@@ -4,4 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\GeometryCollection;
 
-class ExtendedGeometryCollection extends GeometryCollection {}
+class ExtendedGeometryCollection extends GeometryCollection
+{
+}

--- a/tests/TestObjects/ExtendedGeometryCollection.php
+++ b/tests/TestObjects/ExtendedGeometryCollection.php
@@ -4,6 +4,4 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\GeometryCollection;
 
-class ExtendedGeometryCollection extends GeometryCollection
-{
-}
+class ExtendedGeometryCollection extends GeometryCollection {}

--- a/tests/TestObjects/ExtendedLineString.php
+++ b/tests/TestObjects/ExtendedLineString.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
+
+use MatanYadaev\EloquentSpatial\Objects\LineString;
+
+class ExtendedLineString extends LineString {}

--- a/tests/TestObjects/ExtendedLineString.php
+++ b/tests/TestObjects/ExtendedLineString.php
@@ -4,4 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 
-class ExtendedLineString extends LineString {}
+class ExtendedLineString extends LineString
+{
+}

--- a/tests/TestObjects/ExtendedLineString.php
+++ b/tests/TestObjects/ExtendedLineString.php
@@ -4,6 +4,4 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\LineString;
 
-class ExtendedLineString extends LineString
-{
-}
+class ExtendedLineString extends LineString {}

--- a/tests/TestObjects/ExtendedMultiLineString.php
+++ b/tests/TestObjects/ExtendedMultiLineString.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
+
+use MatanYadaev\EloquentSpatial\Objects\MultiLineString;
+
+class ExtendedMultiLineString extends MultiLineString {}

--- a/tests/TestObjects/ExtendedMultiLineString.php
+++ b/tests/TestObjects/ExtendedMultiLineString.php
@@ -4,4 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\MultiLineString;
 
-class ExtendedMultiLineString extends MultiLineString {}
+class ExtendedMultiLineString extends MultiLineString
+{
+}

--- a/tests/TestObjects/ExtendedMultiLineString.php
+++ b/tests/TestObjects/ExtendedMultiLineString.php
@@ -4,6 +4,4 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\MultiLineString;
 
-class ExtendedMultiLineString extends MultiLineString
-{
-}
+class ExtendedMultiLineString extends MultiLineString {}

--- a/tests/TestObjects/ExtendedMultiPoint.php
+++ b/tests/TestObjects/ExtendedMultiPoint.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
+
+use MatanYadaev\EloquentSpatial\Objects\MultiPoint;
+
+class ExtendedMultiPoint extends MultiPoint {}

--- a/tests/TestObjects/ExtendedMultiPoint.php
+++ b/tests/TestObjects/ExtendedMultiPoint.php
@@ -4,4 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\MultiPoint;
 
-class ExtendedMultiPoint extends MultiPoint {}
+class ExtendedMultiPoint extends MultiPoint
+{
+}

--- a/tests/TestObjects/ExtendedMultiPoint.php
+++ b/tests/TestObjects/ExtendedMultiPoint.php
@@ -4,6 +4,4 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\MultiPoint;
 
-class ExtendedMultiPoint extends MultiPoint
-{
-}
+class ExtendedMultiPoint extends MultiPoint {}

--- a/tests/TestObjects/ExtendedMultiPolygon.php
+++ b/tests/TestObjects/ExtendedMultiPolygon.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
+
+use MatanYadaev\EloquentSpatial\Objects\MultiPolygon;
+
+class ExtendedMultiPolygon extends MultiPolygon {}

--- a/tests/TestObjects/ExtendedMultiPolygon.php
+++ b/tests/TestObjects/ExtendedMultiPolygon.php
@@ -4,6 +4,4 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\MultiPolygon;
 
-class ExtendedMultiPolygon extends MultiPolygon
-{
-}
+class ExtendedMultiPolygon extends MultiPolygon {}

--- a/tests/TestObjects/ExtendedMultiPolygon.php
+++ b/tests/TestObjects/ExtendedMultiPolygon.php
@@ -4,4 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\MultiPolygon;
 
-class ExtendedMultiPolygon extends MultiPolygon {}
+class ExtendedMultiPolygon extends MultiPolygon
+{
+}

--- a/tests/TestObjects/ExtendedPoint.php
+++ b/tests/TestObjects/ExtendedPoint.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
+
+use MatanYadaev\EloquentSpatial\Objects\Point;
+
+class ExtendedPoint extends Point {}

--- a/tests/TestObjects/ExtendedPoint.php
+++ b/tests/TestObjects/ExtendedPoint.php
@@ -4,6 +4,4 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\Point;
 
-class ExtendedPoint extends Point
-{
-}
+class ExtendedPoint extends Point {}

--- a/tests/TestObjects/ExtendedPoint.php
+++ b/tests/TestObjects/ExtendedPoint.php
@@ -4,4 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\Point;
 
-class ExtendedPoint extends Point {}
+class ExtendedPoint extends Point
+{
+}

--- a/tests/TestObjects/ExtendedPolygon.php
+++ b/tests/TestObjects/ExtendedPolygon.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
+
+use MatanYadaev\EloquentSpatial\Objects\Polygon;
+
+class ExtendedPolygon extends Polygon {}

--- a/tests/TestObjects/ExtendedPolygon.php
+++ b/tests/TestObjects/ExtendedPolygon.php
@@ -4,4 +4,6 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\Polygon;
 
-class ExtendedPolygon extends Polygon {}
+class ExtendedPolygon extends Polygon
+{
+}

--- a/tests/TestObjects/ExtendedPolygon.php
+++ b/tests/TestObjects/ExtendedPolygon.php
@@ -4,6 +4,4 @@ namespace MatanYadaev\EloquentSpatial\Tests\TestObjects;
 
 use MatanYadaev\EloquentSpatial\Objects\Polygon;
 
-class ExtendedPolygon extends Polygon
-{
-}
+class ExtendedPolygon extends Polygon {}

--- a/tests/database/migrations-laravel-<=10/0000_00_00_000000_create_test_extended_places_table.php
+++ b/tests/database/migrations-laravel-<=10/0000_00_00_000000_create_test_extended_places_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestExtendedPlacesTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('test_extended_places', function (Blueprint $table): void {
+            $table->id();
+            $table->timestamps();
+            $table->string('name');
+            $table->string('address');
+            $table->point('point')->isGeometry()->nullable();
+            $table->multiPoint('multi_point')->isGeometry()->nullable();
+            $table->lineString('line_string')->isGeometry()->nullable();
+            $table->multiLineString('multi_line_string')->isGeometry()->nullable();
+            $table->polygon('polygon')->isGeometry()->nullable();
+            $table->multiPolygon('multi_polygon')->isGeometry()->nullable();
+            $table->geometryCollection('geometry_collection')->isGeometry()->nullable();
+            $table->point('point_with_line_string_cast')->isGeometry()->nullable();
+            $table->point('point_geography')->nullable();
+            $table->decimal('longitude')->nullable();
+            $table->decimal('latitude')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('test_extended_places');
+    }
+}

--- a/tests/database/migrations-laravel->=11/0000_00_00_000000_create_test_extended_places_table.php
+++ b/tests/database/migrations-laravel->=11/0000_00_00_000000_create_test_extended_places_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestExtendedPlacesTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('test_extended_places', function (Blueprint $table): void {
+            $table->id();
+            $table->timestamps();
+            $table->string('name');
+            $table->string('address');
+            $table->geometry('point', 'point')->nullable();
+            $table->geometry('multi_point', 'multipoint')->nullable();
+            $table->geometry('line_string', 'linestring')->nullable();
+            $table->geometry('multi_line_string', 'multilinestring')->nullable();
+            $table->geometry('polygon', 'polygon')->nullable();
+            $table->geometry('multi_polygon', 'multipolygon')->nullable();
+            $table->geometry('geometry_collection', 'geometrycollection')->nullable();
+            $table->geometry('point_with_line_string_cast', 'point')->nullable();
+            $table->decimal('longitude')->nullable();
+            $table->decimal('latitude')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('test_extended_places');
+    }
+}


### PR DESCRIPTION
This PR adds support for custom geometry classes by extending the current geometry classes.

I was looking for a way to modify some of the array data returned by `Point::toArray()` method and was unable to do so. 
After searching through recent PR's and issues I stumbled upon #63 which actually adds this functionality, but it was closed because the solution was "too complicated and not elegant".

Although this PR does not really differs from the one you already made (#63) I think people can benefit from this functionality, thats why I would like to give it another try.

The only real difference between #63 and this PR is the way of using the custom geometry classes by making it look more "Laravel-ish", for example looking at Laravel Jetstream how it uses custom User, Team, Membership and TeamInvitation models. (https://github.com/laravel/jetstream/blob/5.x/src/Jetstream.php#L282)

Thank you for creating this package!