### PR TITLE
Fix WKT for empty geometry collections

### DIFF
--- a/src/Objects/GeometryCollection.php
+++ b/src/Objects/GeometryCollection.php
@@ -42,6 +42,10 @@ class GeometryCollection extends Geometry implements ArrayAccess
     {
         $wktData = $this->getWktData();
 
+        if ($wktData === '') {
+            return 'GEOMETRYCOLLECTION EMPTY';
+        }
+
         return "GEOMETRYCOLLECTION({$wktData})";
     }
 

--- a/tests/Objects/GeometryCollectionTest.php
+++ b/tests/Objects/GeometryCollectionTest.php
@@ -669,3 +669,9 @@ it('throws exception when storing a record with extended GeometryCollection inst
         TestPlace::factory()->create(['geometry_collection' => $geometryCollection]);
     })->toThrow(InvalidArgumentException::class);
 });
+
+it('generates empty geometry collection WKT', function (): void {
+    $geometryCollection = new GeometryCollection([]);
+
+    expect($geometryCollection->toWkt())->toBe('GEOMETRYCOLLECTION EMPTY');
+});


### PR DESCRIPTION
Empty geometry collections should generate their WKT as `GEOMETRYCOLLECTION EMPTY` instead of `GEOMETRYCOLLECTION()`

```php
$empty = new MatanYadaev\EloquentSpatial\Objects\GeometryCollection([], 4326);

$emptyWkt = $empty->toWkt();
// "GEOMETRYCOLLECTION()"

$parsed = MatanYadaev\EloquentSpatial\Objects\Geometry::fromWkt($emptyWkt, 4326);
// InvalidArgumentException: Invalid spatial value.
```