### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -16,7 +16,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ 8.5, 8.4, 8.3, 8.2 ]
-                laravel: [ 12.*, 11.* ]
+                laravel: [ 13.*, 12.*, 11.* ]
                 db: [ 'mysql:8.0', 'mysql:5.7', 'mariadb:10.11', 'postgis/postgis:16-3.4', 'postgis/postgis:15-3.4', 'postgis/postgis:14-3.4', 'postgis/postgis:13-3.4', 'postgis/postgis:12-3.4' ]
                 dependency-version: [ prefer-stable ]
                 include:
@@ -24,9 +24,13 @@ jobs:
                         testbench: ^9.0
                     -   laravel: 12.*
                         testbench: ^10.0
+                    -   laravel: 13.*
+                        testbench: ^11.0
                 exclude:
                     -   laravel: 11.*
                         php: 8.5
+                    -   laravel: 13.*
+                        php: 8.2
 
         services:
             db:

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         "php": "^8.1",
         "ext-json": "*",
         "ext-pdo": "*",
-        "laravel/framework": "^10.0|^11.0|^12.0",
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
         "brick/geo": "0.13.*"
     },
     "require-dev": {
         "doctrine/dbal": "^3.5.3|^4.2",
         "larastan/larastan": "^1.0|^2.4|^3.1",
         "laravel/pint": "^1.14",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^2.0|^3.7|^4.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.1|^4.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,5 +21,12 @@ parameters:
       identifier: method.nonObject
     -
       identifier: varTag.nativeType
+    -
+      message: '#expects .*literal-string#'
+      paths:
+        - src/Traits/HasSpatial.php
+        - src/Objects/Geometry.php
+        - tests/GeometryCastTest.php
+        - tests/HasSpatialTest.php
 
   level: max

--- a/src/Objects/GeometryCollection.php
+++ b/src/Objects/GeometryCollection.php
@@ -169,7 +169,6 @@ class GeometryCollection extends Geometry implements ArrayAccess
      */
     private function isExtended(): bool
     {
-        // @phpstan-ignore-next-line function.alreadyNarrowedType
         return is_subclass_of(static::class, self::class);
     }
 }

--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Support\Facades\DB;
+use Pest\Expectation;
 
 expect()->extend('toBeOnPostgres', function (mixed $value) {
     return $this->when(DB::connection() instanceof PostgresConnection, fn () => $this->toBe($value));
@@ -11,12 +12,12 @@ expect()->extend('toBeOnMysql', function (mixed $value) {
     return $this->when(! (DB::connection() instanceof PostgresConnection), fn () => $this->toBe($value));
 });
 
-expect()->extend('toBeInstanceOfOnPostgres', function (string $type): Pest\Expectation {
+expect()->extend('toBeInstanceOfOnPostgres', function (string $type): Expectation {
     /** @var class-string $type */
     return $this->when(DB::connection() instanceof PostgresConnection, fn () => $this->toBeInstanceOf($type));
 });
 
-expect()->extend('toBeInstanceOfOnMysql', function (string $type): Pest\Expectation {
+expect()->extend('toBeInstanceOfOnMysql', function (string $type): Expectation {
     /** @var class-string $type */
     return $this->when(! (DB::connection() instanceof PostgresConnection), fn () => $this->toBeInstanceOf($type));
 });


### PR DESCRIPTION
## Summary
- Add `laravel/framework ^13.0` and `orchestra/testbench ^11.0` to composer.json
- Add Laravel 13 to CI test matrix
- Exclude PHP 8.2 for Laravel 13 (requires PHP >= 8.3)

Closes #146