### PR TITLE
Harden standalone support and fix MariaDB ST_CROSSES CI regression

### DIFF
--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -16,19 +16,15 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ 8.5, 8.4, 8.3, 8.2 ]
-                laravel: [ 13.*, 12.*, 11.* ]
-                db: [ 'mysql:8.0', 'mysql:5.7', 'mariadb:10.11', 'postgis/postgis:16-3.4', 'postgis/postgis:15-3.4', 'postgis/postgis:14-3.4', 'postgis/postgis:13-3.4', 'postgis/postgis:12-3.4' ]
+                laravel: [ 13.*, 12.* ]
+                db: [ 'mysql:8.4', 'mariadb:10.11.16', 'postgis/postgis:18-3.6', 'postgis/postgis:17-3.5', 'postgis/postgis:16-3.4', 'postgis/postgis:15-3.4', 'postgis/postgis:14-3.4' ]
                 dependency-version: [ prefer-stable ]
                 include:
-                    -   laravel: 11.*
-                        testbench: ^9.0
                     -   laravel: 12.*
                         testbench: ^10.0
                     -   laravel: 13.*
                         testbench: ^11.0
                 exclude:
-                    -   laravel: 11.*
-                        php: 8.5
                     -   laravel: 13.*
                         php: 8.2
 
@@ -66,16 +62,6 @@ jobs:
                 if: contains(matrix.db, 'postgis')
                 run: |
                     echo "DB_CONNECTION=pgsql" >> "$GITHUB_ENV"
-
-            -   name: Set DB_CONNECTION env variable (MariaDB & Laravel 11)
-                if: contains(matrix.laravel, '11') && contains(matrix.db, 'mariadb')
-                run: |
-                    echo "DB_CONNECTION=mariadb" >> "$GITHUB_ENV"
-
-            -   name: Set DB_COLLATION env variable (Mysql 5.7 & Laravel 11)
-                if: contains(matrix.laravel, '11') && contains(matrix.db, 'mysql:5.7')
-                run: |
-                    echo "DB_COLLATION=utf8mb4_unicode_ci" >> "$GITHUB_ENV"
 
             -   name: Execute tests
                 env:

--- a/README.md
+++ b/README.md
@@ -148,28 +148,21 @@ echo $vacationCity->area->toJson(); // {"type":"Polygon","coordinates":[[[41.907
 
 ### Standalone Eloquent Usage (without Laravel)
 
-This package can also be used in standalone PHP projects utilizing only Eloquent (`illuminate/database` and `illuminate/support`).
+This package also works in projects that use Eloquent on its own, without the full Laravel framework.
 
-1. **Bootstrap Setup**:
-   Ensure you initialize your database connection (e.g., via `Illuminate\Database\Capsule\Manager`):
-   ```php
-   use Illuminate\Database\Capsule\Manager as Capsule;
+Just boot Eloquent — for example, with `Illuminate\Database\Capsule\Manager` — and the spatial casts, scopes, and objects are ready to use:
 
-   $capsule = new Capsule;
-   $capsule->addConnection([
-       // your database configuration
-   ]);
-   $capsule->bootEloquent();
-   ```
+```php
+use Illuminate\Database\Capsule\Manager as Capsule;
 
-2. **Set Default SRID (Optional)**:
-   By default, the SRID is set to 0. If you need a custom default SRID (e.g., WGS84), you can set it during your application bootstrap:
-   ```php
-   use MatanYadaev\EloquentSpatial\EloquentSpatial;
-   use MatanYadaev\EloquentSpatial\Enums\Srid;
+$capsule = new Capsule;
+$capsule->addConnection([
+    // your database configuration
+]);
+$capsule->bootEloquent();
+```
 
-   EloquentSpatial::setDefaultSrid(Srid::WGS84);
-   ```
+From there, models, casts, and query scopes behave exactly as in the examples above.
 
 ## Further Reading
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Supported databases:
 
-- MySQL 5.7/8
-- MariaDB 10
-- Postgres 12/13/14/15/16 with PostGIS 3.4
+- MySQL 8.4
+- MariaDB 10.11
+- Postgres 14/15/16/17/18 with PostGIS 3.4/3.5/3.6
 
 ## Getting Started
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "pestphp/pest-plugin-laravel": "^2.0|^3.1|^4.0"
     },
     "suggest": {
-        "laravel/framework": "Required to use the service provider and other Laravel framework features (^10.0|^11.0|^12.0|^13.0)."
+        "laravel/framework": "Required to auto-register the service provider and use the full Laravel framework integration."
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,6 @@ services:
         restart: unless-stopped
     mariadb:
         container_name: mariadb-laravel-eloquent-spatial
-        # Pinned: 10.11.17 regressed ST_CROSSES(LineString, Polygon) via MDEV-36058
         image: mariadb:10.11.16
         environment:
             MYSQL_DATABASE: laravel_eloquent_spatial_test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
     mysql:
         container_name: mysql-laravel-eloquent-spatial
-        image: mysql:8.0
+        image: mysql:8.4
         environment:
             MYSQL_DATABASE: laravel_eloquent_spatial_test
             MYSQL_ALLOW_EMPTY_PASSWORD: true
@@ -14,7 +14,8 @@ services:
         restart: unless-stopped
     mariadb:
         container_name: mariadb-laravel-eloquent-spatial
-        image: mariadb:10.11
+        # Pinned: 10.11.17 regressed ST_CROSSES(LineString, Polygon) via MDEV-36058
+        image: mariadb:10.11.16
         environment:
             MYSQL_DATABASE: laravel_eloquent_spatial_test
             MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/src/EloquentSpatialServiceProvider.php
+++ b/src/EloquentSpatialServiceProvider.php
@@ -23,7 +23,7 @@ class EloquentSpatialServiceProvider extends DatabaseServiceProvider
     // @codeCoverageIgnoreStart
     public function boot(): void
     {
-        if (class_exists(Application::class) && version_compare(Application::VERSION, '11.0.0', '>=')) {
+        if (! class_exists(Application::class) || version_compare(Application::VERSION, '11.0.0', '>=')) {
             return;
         }
 

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,11 +1,15 @@
 <?php
 
-test('facades are not used in src')
-    ->expect('Illuminate\Support\Facades')
-    ->not->toBeUsed()
-    ->ignoring('MatanYadaev\EloquentSpatial\EloquentSpatialServiceProvider');
+arch('only the required illuminate packages are used in src')
+    ->expect('MatanYadaev\EloquentSpatial')
+    ->not->toUse('Illuminate')
+    ->ignoring([
+        'Illuminate\Database',
+        'Illuminate\Support',
+        'Illuminate\Contracts',
+        'MatanYadaev\EloquentSpatial\EloquentSpatialServiceProvider',
+    ]);
 
-test('framework classes are not used in src')
-    ->expect('Illuminate\Foundation')
-    ->not->toBeUsed()
-    ->ignoring('MatanYadaev\EloquentSpatial\EloquentSpatialServiceProvider');
+arch('container-bound global helpers are not used in src')
+    ->expect(['app', 'resolve', 'config', 'event', 'dispatch', 'cache', 'logger', 'report', 'abort', 'now'])
+    ->not->toBeUsed();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,5 @@
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use MatanYadaev\EloquentSpatial\Tests\TestCase;
 
-uses(TestCase::class)->in(__DIR__);
-
-uses(DatabaseTransactions::class)->in(__DIR__);
+uses(TestCase::class, DatabaseTransactions::class)
+    ->in('Objects', 'GeometryCastTest.php', 'HasSpatialTest.php', 'DoctrineTypesTest.php');

--- a/tests/Standalone/StandaloneEloquentTest.php
+++ b/tests/Standalone/StandaloneEloquentTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\Facade;
+use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Tests\Standalone\StandalonePlace;
+
+function standaloneConnection(): Connection
+{
+    $driver = (getenv('DB_CONNECTION') ?: 'mysql') === 'pgsql' ? 'pgsql' : 'mysql';
+
+    $capsule = new Capsule;
+    $capsule->addConnection([
+        'driver' => $driver,
+        'host' => getenv('DB_HOST') ?: '127.0.0.1',
+        'port' => getenv('DB_PORT') ?: ($driver === 'pgsql' ? '5432' : '3306'),
+        'database' => getenv('DB_DATABASE') ?: 'laravel_eloquent_spatial_test',
+        'username' => getenv('DB_USERNAME') ?: 'root',
+        'password' => getenv('DB_PASSWORD') ?: '',
+    ]);
+    $capsule->setAsGlobal();
+    $capsule->bootEloquent();
+
+    return $capsule->getConnection();
+}
+
+function createStandalonePlace(): void
+{
+    $place = new StandalonePlace;
+    $place->location = new Point(0, 0, 4326);
+    $place->save();
+}
+
+beforeEach(function (): void {
+    Facade::clearResolvedInstances();
+    Facade::setFacadeApplication(null);
+
+    $connection = standaloneConnection();
+
+    $connection->getSchemaBuilder()->dropIfExists('standalone_places');
+    $connection->getSchemaBuilder()->create('standalone_places', function ($table): void {
+        $table->id();
+    });
+
+    if ($connection->getDriverName() === 'pgsql') {
+        $connection->statement('ALTER TABLE standalone_places ADD COLUMN location geometry(Point, 4326)');
+    } else {
+        $connection->statement('ALTER TABLE standalone_places ADD COLUMN location POINT');
+    }
+});
+
+afterEach(function (): void {
+    Capsule::connection()->getSchemaBuilder()->dropIfExists('standalone_places');
+});
+
+it('persists and reads a geometry cast without a facade root', function (): void {
+    // Arrange
+    createStandalonePlace();
+
+    // Act
+    /** @var StandalonePlace $fetched */
+    $fetched = StandalonePlace::query()->firstOrFail();
+
+    // Assert
+    expect($fetched->location)->toBeInstanceOf(Point::class)
+        ->and($fetched->location->latitude)->toBe(0.0)
+        ->and($fetched->location->longitude)->toBe(0.0);
+});
+
+it('runs spatial scopes without a facade root', function (): void {
+    // Arrange
+    createStandalonePlace();
+
+    // Act
+    /** @var StandalonePlace $fetched */
+    $fetched = StandalonePlace::query()
+        ->withDistance('location', new Point(1, 1, 4326))
+        ->whereDistance('location', new Point(1, 1, 4326), '<', 1e12)
+        ->firstOrFail();
+
+    // Assert
+    expect($fetched->distance)->toBeNumeric()
+        ->and((float) $fetched->distance)->toBeGreaterThan(0.0);
+});

--- a/tests/Standalone/StandalonePlace.php
+++ b/tests/Standalone/StandalonePlace.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MatanYadaev\EloquentSpatial\Tests\Standalone;
+
+use Illuminate\Database\Eloquent\Model;
+use MatanYadaev\EloquentSpatial\Objects\Point;
+use MatanYadaev\EloquentSpatial\Traits\HasSpatial;
+
+/**
+ * @property Point $location
+ * @property float|null $distance
+ *
+ * @mixin Model
+ */
+class StandalonePlace extends Model
+{
+    use HasSpatial;
+
+    protected $table = 'standalone_places';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    /** @var array<string, string> */
+    protected $casts = ['location' => Point::class];
+}


### PR DESCRIPTION
## Summary

Follow-up hardening on top of #148, plus a fix for the MariaDB CI failure currently breaking `master`.

### Standalone Eloquent support
- Fix the service-provider `boot()` guard so a standalone (non-Laravel) app no longer falls through to the Laravel `<11` Doctrine-type registration path.
- Tighten the architecture tests to enforce a framework-agnostic `src` (allow only `Illuminate\Database|Support|Contracts`, ban container-bound global helpers).
- Expand standalone test coverage and scope `TestCase`/`DatabaseTransactions` to the framework-backed suites only.
- Simplify the standalone usage docs.

### Database test matrix
- **Pin MariaDB to `10.11.16`.** `10.11.17+` regressed `ST_CROSSES(LineString, Polygon)` to return `0` instead of `1` ([MDEV-36058](https://jira.mariadb.org/browse/MDEV-36058), merged from 10.6.26), which broke the `whereCrosses` scope test. MySQL and PostGIS return the correct result.
- Replace EOL databases: MySQL `5.7`/`8.0` → `8.4` LTS; drop PostgreSQL `12`/`13`.
- Drop EOL Laravel `11` (security support ended 2026-03-12) and its now-dead special-case CI steps.
- Add PostgreSQL `17` and `18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)